### PR TITLE
feat: add zstd compression support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ path = "src/lib.rs"
 default = []
 lz4 = ["dep:lz4_flex"]
 miniz = ["dep:miniz_oxide"]
+zstd = ["dep:zstd"]
 bloom = []
-all = ["bloom", "lz4", "miniz"]
+all = ["bloom", "lz4", "miniz", "zstd"]
 
 [dependencies]
 byteorder = "1.5.0"
@@ -40,6 +41,7 @@ tempfile = "3.12.0"
 value-log = "1.0.0"
 varint-rs = "2.2.0"
 xxhash-rust = { version = "0.8.12", features = ["xxh3"] }
+zstd = { version = "0.13.2", optional = true, features = ["experimental"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -72,13 +74,13 @@ required-features = ["bloom"]
 name = "block"
 harness = false
 path = "benches/block.rs"
-required-features = ["lz4", "miniz"]
+required-features = ["lz4", "miniz", "zstd"]
 
 [[bench]]
 name = "tree"
 harness = false
 path = "benches/tree.rs"
-required-features = ["lz4", "miniz"]
+required-features = ["lz4", "miniz", "zstd"]
 
 [[bench]]
 name = "level_manifest"

--- a/benches/block.rs
+++ b/benches/block.rs
@@ -1,11 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use lsm_tree::{
+    coding::Encode,
     segment::{
         block::{header::Header as BlockHeader, ItemSize},
         meta::CompressionType,
         value_block::ValueBlock,
     },
-    serde::Serializable,
     Checksum, InternalValue,
 };
 use std::io::Write;
@@ -106,6 +106,11 @@ fn load_value_block_from_disk(c: &mut Criterion) {
         CompressionType::None,
         CompressionType::Lz4,
         CompressionType::Miniz(6),
+        CompressionType::Zstd(-3),
+        CompressionType::Zstd(-1),
+        CompressionType::Zstd(1),
+        CompressionType::Zstd(3),
+        CompressionType::Zstd(12),
     ] {
         for block_size in [1, 4, 8, 16, 32, 64, 128] {
             let block_size = block_size * 1_024;

--- a/benches/tree.rs
+++ b/benches/tree.rs
@@ -181,7 +181,7 @@ fn tree_get_pairs(c: &mut Criterion) {
         {
             let folder = tempfile::tempdir().unwrap();
             let tree = Config::new(folder)
-                .block_size(1_024)
+                .data_block_size(1_024)
                 .block_cache(Arc::new(BlockCache::with_capacity_bytes(0)))
                 .open()
                 .unwrap();
@@ -219,7 +219,7 @@ fn tree_get_pairs(c: &mut Criterion) {
         {
             let folder = tempfile::tempdir().unwrap();
             let tree = Config::new(folder)
-                .block_size(1_024)
+                .data_block_size(1_024)
                 .block_cache(Arc::new(BlockCache::with_capacity_bytes(0)))
                 .open()
                 .unwrap();
@@ -262,7 +262,7 @@ fn disk_point_read(c: &mut Criterion) {
     let folder = tempdir().unwrap();
 
     let tree = Config::new(folder)
-        .block_size(1_024)
+        .data_block_size(1_024)
         .block_cache(Arc::new(BlockCache::with_capacity_bytes(0)))
         .open()
         .unwrap();
@@ -300,7 +300,7 @@ fn disjoint_tree_minmax(c: &mut Criterion) {
     let folder = tempfile::tempdir().unwrap();
 
     let tree = Config::new(folder)
-        .block_size(1_024)
+        .data_block_size(1_024)
         .block_cache(Arc::new(BlockCache::with_capacity_bytes(0)))
         .open()
         .unwrap();

--- a/src/blob_tree/compression.rs
+++ b/src/blob_tree/compression.rs
@@ -24,6 +24,9 @@ impl Compressor for MyCompressor {
 
             #[cfg(feature = "miniz")]
             CompressionType::Miniz(lvl) => miniz_oxide::deflate::compress_to_vec(bytes, lvl),
+
+            #[cfg(feature = "zstd")]
+            CompressionType::Zstd(level) => zstd::bulk::compress(bytes, level)?,
         })
     }
 
@@ -39,6 +42,14 @@ impl Compressor for MyCompressor {
             #[cfg(feature = "miniz")]
             CompressionType::Miniz(_) => miniz_oxide::inflate::decompress_to_vec(bytes)
                 .map_err(|_| value_log::Error::Decompress),
+
+            #[cfg(feature = "zstd")]
+            CompressionType::Zstd(_) => zstd::bulk::decompress(
+                bytes,
+                // TODO: assuming 4GB output size max
+                u32::MAX as usize,
+            )
+            .map_err(|_| value_log::Error::Decompress),
         }
     }
 }

--- a/tests/blob_simple.rs
+++ b/tests/blob_simple.rs
@@ -132,3 +132,44 @@ fn blob_tree_simple_compressed_2() -> lsm_tree::Result<()> {
 
     Ok(())
 }
+
+#[cfg(feature = "zstd")]
+#[test]
+fn blob_tree_simple_compressed_zstd() -> lsm_tree::Result<()> {
+    let folder = tempfile::tempdir()?;
+    let path = folder.path();
+
+    let tree = lsm_tree::Config::new(path)
+        .compression(lsm_tree::CompressionType::Zstd(3))
+        .open_as_blob_tree()?;
+
+    let big_value = b"neptune!".repeat(128_000);
+
+    assert!(tree.get("big")?.is_none());
+    tree.insert("big", &big_value, 0);
+    tree.insert("smol", "small value", 0);
+
+    let value = tree.get("big")?.expect("should exist");
+    assert_eq!(&*value, big_value);
+
+    tree.flush_active_memtable(0)?;
+
+    let value = tree.get("big")?.expect("should exist");
+    assert_eq!(&*value, big_value);
+
+    let value = tree.get("smol")?.expect("should exist");
+    assert_eq!(&*value, b"small value");
+
+    let new_big_value = b"winter!".repeat(128_000);
+    tree.insert("big", &new_big_value, 1);
+
+    let value = tree.get("big")?.expect("should exist");
+    assert_eq!(&*value, new_big_value);
+
+    tree.flush_active_memtable(0)?;
+
+    let value = tree.get("big")?.expect("should exist");
+    assert_eq!(&*value, new_big_value);
+
+    Ok(())
+}


### PR DESCRIPTION
zstd experimental feature is enabled to calculate upper bound of Vec capacity to be allocated while decompressing data using zstd::bulk::Decompressor::upper_bound.

supported levels are -128~22, with 0 defaulting to level 3 (due to zstd library behaviour).

benchmark Load block from disk

```
Load block from disk/1024 KiB [no compression] time:   [6.0854 µs 6.2072 µs 6.3423 µs]
Load block from disk/1024 KiB [lz4] time:   [7.2133 µs 7.3160 µs 7.4288 µs]
Load block from disk/1024 KiB [miniz] time:   [10.358 µs 10.542 µs 10.740 µs]
Load block from disk/1024 KiB [zstd(-3)] time:   [9.2772 µs 9.5900 µs 9.9649 µs]
Load block from disk/1024 KiB [zstd(-1)] time:   [9.0652 µs 9.1867 µs 9.3248 µs]
Load block from disk/1024 KiB [zstd(1)] time:   [9.0680 µs 9.2127 µs 9.3672 µs]
Load block from disk/1024 KiB [zstd(3)] time:   [9.0162 µs 9.1445 µs 9.2872 µs]
Load block from disk/1024 KiB [zstd(12)] time:   [10.432 µs 10.605 µs 10.795 µs]

Load block from disk/131072 KiB [no compression] time:   [150.79 µs 153.20 µs 155.90 µs]
Load block from disk/131072 KiB [lz4] time:   [193.57 µs 196.56 µs 199.61 µs]
Load block from disk/131072 KiB [miniz] time:   [232.92 µs 236.82 µs 241.00 µs]
Load block from disk/131072 KiB [zstd(-3)] time:   [197.10 µs 199.85 µs 203.01 µs]
Load block from disk/131072 KiB [zstd(-1)] time:   [198.58 µs 201.26 µs 204.22 µs]
Load block from disk/131072 KiB [zstd(1)] time:   [201.25 µs 203.61 µs 206.26 µs]
Load block from disk/131072 KiB [zstd(3)] time:   [197.61 µs 199.59 µs 201.84 µs]
Load block from disk/131072 KiB [zstd(12)] time:   [217.46 µs 220.58 µs 224.06 µs]
```