### PR TITLE
Pass through `bytes` dependency to `value-log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ lz4 = ["dep:lz4_flex"]
 miniz = ["dep:miniz_oxide"]
 bloom = []
 all = ["bloom", "lz4", "miniz"]
+bytes = ["value-log/bytes"]
 
 [dependencies]
 byteorder = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ quick_cache = { version = "0.6.5", default-features = false, features = [] }
 rustc-hash = "2.0.0"
 self_cell = "1.0.4"
 tempfile = "3.12.0"
-value-log = "1.2.0"
+value-log = "1.3.0"
 varint-rs = "2.2.0"
 xxhash-rust = { version = "0.8.12", features = ["xxh3"] }
 

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -43,7 +43,7 @@ impl<I: Iterator<Item = crate::Result<InternalValue>>> CompactionStream<I> {
             };
 
             // Consume version
-            if &next.key.user_key == key {
+            if next.key.user_key == key {
                 // NOTE: We know the next value is not empty, because we just peeked it
                 #[allow(clippy::expect_used)]
                 self.inner.next().expect("should not be empty")?;

--- a/src/level_manifest/level.rs
+++ b/src/level_manifest/level.rs
@@ -173,10 +173,10 @@ impl<'a> DisjointLevel<'a> {
         let lo = match &key_range.0 {
             Bound::Unbounded => 0,
             Bound::Included(start_key) => {
-                level.partition_point(|segment| &segment.metadata.key_range.1 < start_key)
+                level.partition_point(|segment| segment.metadata.key_range.1 < start_key)
             }
             Bound::Excluded(start_key) => {
-                level.partition_point(|segment| &segment.metadata.key_range.1 <= start_key)
+                level.partition_point(|segment| segment.metadata.key_range.1 <= start_key)
             }
         };
 
@@ -187,7 +187,7 @@ impl<'a> DisjointLevel<'a> {
         let hi = match &key_range.1 {
             Bound::Unbounded => level.len() - 1,
             Bound::Included(end_key) => {
-                let idx = level.partition_point(|segment| &segment.metadata.key_range.0 <= end_key);
+                let idx = level.partition_point(|segment| segment.metadata.key_range.0 <= end_key);
 
                 if idx == 0 {
                     return None;
@@ -196,7 +196,7 @@ impl<'a> DisjointLevel<'a> {
                 idx.saturating_sub(1) // To avoid underflow
             }
             Bound::Excluded(end_key) => {
-                let idx = level.partition_point(|segment| &segment.metadata.key_range.0 < end_key);
+                let idx = level.partition_point(|segment| segment.metadata.key_range.0 < end_key);
 
                 if idx == 0 {
                     return None;

--- a/src/mvcc_stream.rs
+++ b/src/mvcc_stream.rs
@@ -38,7 +38,7 @@ impl<I: DoubleEndedIterator<Item = crate::Result<InternalValue>>> MvccStream<I> 
             };
 
             // Consume version
-            if &next.key.user_key == key {
+            if next.key.user_key == key {
                 // NOTE: We know the next value is not empty, because we just peeked it
                 #[allow(clippy::expect_used)]
                 self.inner.next().expect("should not be empty")?;

--- a/src/segment/block_index/mod.rs
+++ b/src/segment/block_index/mod.rs
@@ -37,7 +37,7 @@ impl BlockIndex for [KeyedBlockHandle] {
                 return Ok(None);
             };
 
-            if &last_block.end_key < key {
+            if last_block.end_key < key {
                 return Ok(None);
             }
 


### PR DESCRIPTION
Required for https://github.com/fjall-rs/fjall/issues/94
Depends on: 
- https://github.com/fjall-rs/value-log/pull/10

This PR changes many explicit Slice refs into Slice due to the new PartialEq/PartialOrd generic implementation that no longer requires an explicit ref. I don't think this changes any runtime behavior, but please tell me if this assumption is wrong!