### PR TITLE
Impl Error::source

### DIFF
--- a/src/coding.rs
+++ b/src/coding.rs
@@ -29,6 +29,14 @@ impl From<std::io::Error> for EncodeError {
     }
 }
 
+impl std::error::Error for EncodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+        }
+    }
+}
+
 /// Error during deserialization
 #[derive(Debug)]
 pub enum DecodeError {
@@ -70,6 +78,16 @@ impl From<std::io::Error> for DecodeError {
 impl From<std::str::Utf8Error> for DecodeError {
     fn from(value: std::str::Utf8Error) -> Self {
         Self::Utf8(value)
+    }
+}
+
+impl std::error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Utf8(e) => Some(e),
+            _ => None,
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,20 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Encode(e) => Some(e),
+            Self::Decode(e) => Some(e),
+            Self::Decompress(_) => None,
+            Self::InvalidVersion(_) => None,
+            Self::Unrecoverable => None,
+            Self::InvalidChecksum(_) => None,
+            Self::ValueLog(e) => Some(e),
+        }
+    }
+}
 
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {


### PR DESCRIPTION
By implementing Error::source, it allows a user to extract io::Errors without importing all fjall crates and manually spidering Fjall's error enums.

Depends on https://github.com/fjall-rs/value-log/pull/24