### PR TITLE
Show the default LCS level ratio in Strategy doc comment

### DIFF
--- a/src/compaction/leveled.rs
+++ b/src/compaction/leveled.rs
@@ -168,6 +168,8 @@ pub struct Strategy {
 
     /// Size ratio between levels of the LSM tree (a.k.a fanout, growth rate)
     ///
+    /// Default = 10
+    ///
     /// This is the exponential growth of the from one.
     /// level to the next
     ///


### PR DESCRIPTION
unless there's a reason it was excluded -- didn't spot anything obvious :)