### PR TITLE
Update xxhash usage to rely on default hasher

### DIFF
--- a/src/compaction/fifo.rs
+++ b/src/compaction/fifo.rs
@@ -51,7 +51,7 @@ impl CompactionStrategy for Strategy {
         #[allow(clippy::expect_used)]
         let first_level = resolved_view.first().expect("L0 should always exist");
 
-        let mut segment_ids_to_delete = HashSet::with_hasher(xxhash_rust::xxh3::Xxh3Builder::new());
+        let mut segment_ids_to_delete = HashSet::with_hasher(Default::default());
 
         if let Some(ttl_seconds) = self.ttl_seconds {
             if ttl_seconds > 0 {

--- a/src/descriptor_table/mod.rs
+++ b/src/descriptor_table/mod.rs
@@ -77,7 +77,7 @@ impl FileDescriptorTable {
             inner: RwLock::new(FileDescriptorTableInner {
                 table: HashMap::with_capacity_and_hasher(
                     100,
-                    xxhash_rust::xxh3::Xxh3Builder::new(),
+                    Default::default(),
                 ),
                 lru: Mutex::new(LruList::with_capacity(100)),
                 size: AtomicUsize::default(),

--- a/src/level_manifest/hidden_set.rs
+++ b/src/level_manifest/hidden_set.rs
@@ -15,7 +15,7 @@ pub struct HiddenSet {
 impl Default for HiddenSet {
     fn default() -> Self {
         Self {
-            set: HashSet::with_capacity_and_hasher(10, xxhash_rust::xxh3::Xxh3Builder::new()),
+            set: HashSet::with_capacity_and_hasher(10, Default::default()),
         }
     }
 }

--- a/src/level_manifest/mod.rs
+++ b/src/level_manifest/mod.rs
@@ -365,7 +365,7 @@ impl LevelManifest {
     #[must_use]
     pub fn busy_levels(&self) -> HashSet<u8> {
         let mut output =
-            HashSet::with_capacity_and_hasher(self.len(), xxhash_rust::xxh3::Xxh3Builder::new());
+            HashSet::with_capacity_and_hasher(self.len(), Default::default());
 
         for (idx, level) in self.levels.iter().enumerate() {
             if level.ids().any(|id| self.hidden_set.is_hidden(id)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,8 @@
 #![allow(clippy::option_if_let_else)]
 #![warn(clippy::needless_lifetimes)]
 
-pub(crate) type HashMap<K, V> = std::collections::HashMap<K, V, xxhash_rust::xxh3::Xxh3Builder>;
-pub(crate) type HashSet<K> = std::collections::HashSet<K, xxhash_rust::xxh3::Xxh3Builder>;
+pub(crate) type HashMap<K, V> = std::collections::HashMap<K, V, xxhash_rust::xxh3::Xxh3DefaultBuilder>;
+pub(crate) type HashSet<K> = std::collections::HashSet<K, xxhash_rust::xxh3::Xxh3DefaultBuilder>;
 
 #[allow(unused)]
 macro_rules! set {


### PR DESCRIPTION
This hasher has smaller size which is best to how std library uses hasher