### PR TITLE
in tree, store Config in Arc to avoid large copies during compaction

### DIFF
--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -43,7 +43,7 @@ pub struct Options {
     pub blob_file_id_generator: SequenceNumberCounter,
 
     /// Configuration of tree.
-    pub config: Config,
+    pub config: Arc<Config>,
 
     pub version_history: Arc<RwLock<SuperVersions>>,
 

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -51,7 +51,7 @@ pub struct TreeInner {
     pub(crate) compaction_state: Arc<Mutex<CompactionState>>,
 
     /// Tree configuration
-    pub config: Config,
+    pub config: Arc<Config>,
 
     /// Compaction may take a while; setting the signal to `true`
     /// will interrupt the compaction and kill the worker.
@@ -87,7 +87,7 @@ impl TreeInner {
             memtable_id_counter: SequenceNumberCounter::default(),
             table_id_counter: SequenceNumberCounter::default(),
             blob_file_id_counter: SequenceNumberCounter::default(),
-            config,
+            config: Arc::new(config),
             version_history: Arc::new(RwLock::new(SuperVersions::new(version))),
             stop_signal: StopSignal::default(),
             major_compaction_lock: RwLock::default(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -950,7 +950,7 @@ impl Tree {
             blob_file_id_counter: SequenceNumberCounter::default(),
             version_history: Arc::new(RwLock::new(SuperVersions::new(version))),
             stop_signal: StopSignal::default(),
-            config,
+            config: Arc::new(config),
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),


### PR DESCRIPTION
Compaction will clone config. Use Arc to reduce overhead.