### PR TITLE
Add Guard::into_inner_if_some

### DIFF
--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -61,7 +61,7 @@ impl IterGuard for Guard {
     fn into_inner_if_some<T>(
         self,
         pred: impl Fn(&UserKey) -> Option<T>,
-    ) -> crate::Result<Option<(T, UserValue)>> {
+    ) -> crate::Result<Result<(T, UserValue), UserKey>> {
         let kv = self.kv?;
 
         if let Some(t) = pred(&kv.key.user_key) {
@@ -73,9 +73,9 @@ impl IterGuard for Guard {
                 &self.version,
                 kv,
             )
-            .map(|(_, v)| Some((t, v)))
+            .map(|(_, v)| Ok((t, v)))
         } else {
-            Ok(None)
+            Ok(Err(kv.key.user_key))
         }
     }
 

--- a/src/iter_guard.rs
+++ b/src/iter_guard.rs
@@ -30,7 +30,7 @@ pub trait IterGuard {
     fn into_inner_if_some<T>(
         self,
         pred: impl Fn(&UserKey) -> Option<T>,
-    ) -> crate::Result<Option<(T, UserValue)>>;
+    ) -> crate::Result<Result<(T, UserValue), UserKey>>;
 
     /// Accesses the key-value pair.
     ///

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -52,13 +52,13 @@ impl IterGuard for Guard {
     fn into_inner_if_some<T>(
         self,
         pred: impl Fn(&UserKey) -> Option<T>,
-    ) -> crate::Result<Option<(T, UserValue)>> {
+    ) -> crate::Result<Result<(T, UserValue), UserKey>> {
         let (k, v) = self.0?;
 
         if let Some(t) = pred(&k) {
-            Ok(Some((t, v)))
+            Ok(Ok((t, v)))
         } else {
-            Ok(None)
+            Ok(Err(k))
         }
     }
 

--- a/tests/guard_if.rs
+++ b/tests/guard_if.rs
@@ -100,6 +100,7 @@ fn guard_into_inner_if_some() -> lsm_tree::Result<()> {
                             }
                         })
                         .unwrap()
+                        .ok()
                 })
                 .count(),
         );
@@ -139,6 +140,7 @@ fn guard_into_inner_if_some_blob() -> lsm_tree::Result<()> {
                             }
                         })
                         .unwrap()
+                        .ok()
                 })
                 .count(),
         );


### PR DESCRIPTION
Allows passing the Key slice to the predicate and receiving a parsed value, returning that parsed value as the first element of the returned tuple. This can avoid double-parsing of keys that might happen with just Guard::into_inner_if