### PR TITLE
Provide an `as_slice` method on the Slice type

### DIFF
--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -249,4 +249,12 @@ mod tests {
         let slice = Slice::from_reader(&mut reader, 4).expect("read");
         assert_eq!(slice, vec![1, 2, 3, 4]);
     }
+
+    /// Verifies that `Slice::as_slice` returns the data as-is.
+    #[test]
+    fn test_slice_as_slice() {
+        let original = [1_u8, 2, 3, 4];
+        let slice = Slice::from_iter(original.iter().copied());
+        assert_eq!(slice.as_slice(), original);
+    }
 }

--- a/src/slice/slice_bytes/mod.rs
+++ b/src/slice/slice_bytes/mod.rs
@@ -22,7 +22,7 @@ impl Slice {
     /// Returns the bytes slice containing the entire data.
     #[must_use]
     pub fn as_slice(&self) -> &[u8] {
-        &self
+        self
     }
 
     #[doc(hidden)]

--- a/src/slice/slice_bytes/mod.rs
+++ b/src/slice/slice_bytes/mod.rs
@@ -19,6 +19,12 @@ impl Slice {
         Self(Bytes::copy_from_slice(bytes))
     }
 
+    /// Returns the bytes slice containing the entire data.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        &self
+    }
+
     #[doc(hidden)]
     #[must_use]
     pub fn empty() -> Self {

--- a/src/slice/slice_default/mod.rs
+++ b/src/slice/slice_default/mod.rs
@@ -22,7 +22,7 @@ impl Slice {
     /// Returns the bytes slice containing the entire data.
     #[must_use]
     pub fn as_slice(&self) -> &[u8] {
-        &self
+        self
     }
 
     #[doc(hidden)]

--- a/src/slice/slice_default/mod.rs
+++ b/src/slice/slice_default/mod.rs
@@ -19,6 +19,12 @@ impl Slice {
         Self(bytes.into())
     }
 
+    /// Returns the bytes slice containing the entire data.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        &self
+    }
+
     #[doc(hidden)]
     #[must_use]
     pub fn empty() -> Self {


### PR DESCRIPTION
Hey!

I made this small helper similar to [the one in the stdlib](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.as_slice) after having to write `buf.extend(&slice as &[u8]);` a bunch of times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public read-only accessor that returns the full underlying byte data as a borrowed slice, enabling direct, zero-copy reads.
* **Tests**
  * Added a unit test confirming the accessor returns the original byte data unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->