### PR TITLE
chore: allow associating a seqno with a clear action on a tree, and return it in .get_highest_persisted_seqno()

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -175,6 +175,16 @@ pub trait AbstractTree {
     /// Will return `Err` only if an IO error occurs.
     fn clear(&self) -> crate::Result<()>;
 
+    /// Drops all tables and clears all memtables atomically.
+    ///
+    /// Optionally stores an external sequence number corresponding to the clear, which (if
+    /// non-empty) will be returned by subsequent calls to [`get_highest_persisted_seqno`]
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` only if an IO error occurs.
+    fn clear_at_seqno(&self, seqno: Option<SeqNo>) -> crate::Result<()>;
+
     /// Performs major compaction, blocking the caller until it's done.
     ///
     /// # Errors

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -270,6 +270,10 @@ impl AbstractTree for BlobTree {
     }
 
     fn clear(&self) -> crate::Result<()> {
+        self.clear_at_seqno(None)
+    }
+
+    fn clear_at_seqno(&self, seqno: Option<SeqNo>) -> crate::Result<()> {
         let config = self.tree_config();
         let mut versions = self.get_version_history_lock();
 
@@ -280,7 +284,11 @@ impl AbstractTree for BlobTree {
                 copy.active_memtable =
                     Arc::new(Memtable::new(self.index.memtable_id_counter.next()));
                 copy.sealed_memtables = Arc::default();
-                copy.version = Version::new(v.version.id() + 1, self.tree_type());
+                copy.version = Version::new_cleared(
+                    v.version.id() + 1,
+                    self.tree_type(),
+                    copy.version.cleared_seqno.max(seqno),
+                );
                 Ok(copy)
             },
             &config.seqno,
@@ -582,7 +590,9 @@ impl AbstractTree for BlobTree {
     }
 
     fn get_highest_persisted_seqno(&self) -> Option<SeqNo> {
-        self.index.get_highest_persisted_seqno()
+        let inner = self.index.get_highest_seqno();
+
+        self.current_version().cleared_seqno.max(inner)
     }
 
     fn insert<K: Into<UserKey>, V: Into<UserValue>>(

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -262,6 +262,10 @@ impl AbstractTree for Tree {
     }
 
     fn clear(&self) -> crate::Result<()> {
+        self.clear_at_seqno(None)
+    }
+
+    fn clear_at_seqno(&self, seqno: Option<SeqNo>) -> crate::Result<()> {
         let config = self.tree_config();
         let mut versions = self.get_version_history_lock();
 
@@ -271,7 +275,11 @@ impl AbstractTree for Tree {
                 let mut copy = v.clone();
                 copy.active_memtable = Arc::new(Memtable::new(self.memtable_id_counter.next()));
                 copy.sealed_memtables = Arc::default();
-                copy.version = Version::new(v.version.id() + 1, self.tree_type());
+                copy.version = Version::new_cleared(
+                    v.version.id() + 1,
+                    self.tree_type(),
+                    copy.version.cleared_seqno.max(seqno),
+                );
                 Ok(copy)
             },
             &config.seqno,
@@ -630,10 +638,14 @@ impl AbstractTree for Tree {
     }
 
     fn get_highest_persisted_seqno(&self) -> Option<SeqNo> {
-        self.current_version()
+        let current_version = self.current_version();
+
+        let from_table = current_version
             .iter_tables()
             .map(Table::get_highest_seqno)
-            .max()
+            .max();
+
+        current_version.cleared_seqno.max(from_table)
     }
 
     fn get<K: AsRef<[u8]>>(&self, key: K, seqno: SeqNo) -> crate::Result<Option<UserValue>> {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -22,7 +22,7 @@ use crate::version::recovery::Recovery;
 use crate::TreeType;
 use crate::{
     vlog::{BlobFile, BlobFileId},
-    HashSet, KeyRange, Table, TableId,
+    HashSet, KeyRange, SeqNo, Table, TableId,
 };
 use optimize::optimize_runs;
 use run::Ranged;
@@ -158,6 +158,9 @@ pub struct VersionInner {
 
     /// Blob file fragmentation
     gc_stats: Arc<FragmentationMap>,
+
+    /// The external sequence number at which this version was cleared
+    pub(crate) cleared_seqno: Option<SeqNo>,
 }
 
 /// A version is an immutable, point-in-time view of a tree's structure
@@ -209,6 +212,15 @@ impl Version {
 
     /// Creates a new empty version.
     pub fn new(id: VersionId, tree_type: TreeType) -> Self {
+        Self::new_cleared(id, tree_type, None)
+    }
+
+    /// Creates a new empty version with a populated `cleared_seqno`
+    pub(crate) fn new_cleared(
+        id: VersionId,
+        tree_type: TreeType,
+        cleared_seqno: Option<SeqNo>,
+    ) -> Self {
         let levels = (0..DEFAULT_LEVEL_COUNT).map(|_| Level::empty()).collect();
 
         Self {
@@ -218,6 +230,7 @@ impl Version {
                 levels,
                 blob_files: Arc::default(),
                 gc_stats: Arc::default(),
+                cleared_seqno,
             }),
         }
     }
@@ -259,13 +272,18 @@ impl Version {
             })
             .collect::<crate::Result<Vec<_>>>()?;
 
-        Ok(Self::from_levels(
-            recovery.curr_version_id,
-            recovery.tree_type,
-            version_levels,
-            BlobFileList::new(blob_files.iter().cloned().map(|bf| (bf.id(), bf)).collect()),
-            recovery.gc_stats,
-        ))
+        Ok(Self {
+            inner: Arc::new(VersionInner {
+                id: recovery.curr_version_id,
+                tree_type: recovery.tree_type,
+                levels: version_levels,
+                blob_files: Arc::new(BlobFileList::new(
+                    blob_files.iter().cloned().map(|bf| (bf.id(), bf)).collect(),
+                )),
+                gc_stats: Arc::new(recovery.gc_stats),
+                cleared_seqno: recovery.cleared_seqno,
+            }),
+        })
     }
 
     /// Creates a new pre-populated version.
@@ -283,6 +301,7 @@ impl Version {
                 levels,
                 blob_files: Arc::new(blob_files),
                 gc_stats: Arc::new(gc_stats),
+                cleared_seqno: None,
             }),
         }
     }
@@ -391,6 +410,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
+                cleared_seqno: self.cleared_seqno,
             }),
         }
     }
@@ -475,6 +495,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
+                cleared_seqno: self.cleared_seqno,
             }),
         })
     }
@@ -556,6 +577,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
+                cleared_seqno: self.cleared_seqno,
             }),
         }
     }
@@ -604,6 +626,7 @@ impl Version {
                 levels,
                 blob_files: self.blob_files.clone(),
                 gc_stats: self.gc_stats.clone(),
+                cleared_seqno: self.cleared_seqno,
             }),
         }
     }
@@ -698,6 +721,12 @@ impl Version {
         writer.start("blob_gc_stats")?;
 
         self.gc_stats.encode_into(writer)?;
+
+        if let Some(seqno) = self.cleared_seqno {
+            writer.start("cleared_seqno")?;
+
+            writer.write_u64::<LittleEndian>(seqno)?;
+        }
 
         Ok(())
     }

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -29,6 +29,7 @@ pub struct Recovery {
     pub table_ids: Vec<Vec<Vec<RecoveredTable>>>,
     pub blob_file_ids: Vec<(BlobFileId, Checksum)>,
     pub gc_stats: crate::blob_tree::FragmentationMap,
+    pub cleared_seqno: Option<SeqNo>,
 }
 
 pub fn recover(folder: &Path) -> crate::Result<Recovery> {
@@ -139,6 +140,16 @@ pub fn recover(folder: &Path) -> crate::Result<Recovery> {
         crate::blob_tree::FragmentationMap::decode_from(&mut reader)?
     };
 
+    let cleared_seqno = {
+        if let Some(section) = toc.section(b"cleared_seqno") {
+            let mut reader = section.buf_reader(&version_file_path)?;
+            let value = reader.read_u64::<LittleEndian>()?;
+            Some(value)
+        } else {
+            None
+        }
+    };
+
     Ok(Recovery {
         tree_type: {
             let byte = toc.section(b"tree_type").ok_or(crate::Error::Unrecoverable)
@@ -156,5 +167,6 @@ pub fn recover(folder: &Path) -> crate::Result<Recovery> {
         table_ids: levels,
         blob_file_ids,
         gc_stats,
+        cleared_seqno,
     })
 }

--- a/tests/tree_clear.rs
+++ b/tests/tree_clear.rs
@@ -41,3 +41,26 @@ fn tree_clear() -> lsm_tree::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn tree_clear_at_seqno() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+
+    let seqno = SequenceNumberCounter::default();
+    let visible_seqno = SequenceNumberCounter::default();
+    let external_seqno = SequenceNumberCounter::default();
+
+    let tree = Config::new(&folder, seqno.clone(), visible_seqno.clone()).open()?;
+
+    assert!(tree.get_highest_persisted_seqno().is_none());
+    let seqno = external_seqno.next();
+    tree.clear_at_seqno(Some(seqno))?;
+    assert_eq!(tree.get_highest_persisted_seqno(), Some(seqno));
+    let insert_seqno = external_seqno.next();
+    tree.insert(b"foo", b"bar", insert_seqno);
+    tree.flush_active_memtable(insert_seqno)
+        .expect("should flush");
+    assert_eq!(tree.get_highest_persisted_seqno(), Some(insert_seqno));
+
+    Ok(())
+}


### PR DESCRIPTION
This is my attempt to fix fjall-rs/fjall#288.

It modifies the `lsm-tree` to optionally store a seqno associated with clear, and to return it from `.get_highest_persisted_seqno()`.

The code is a little messy, but I didn't want to spend too much time on it before validating with y'all that this seems like a reasonable approach. 

This change is backwards-compatible (since the field is optional), and semi-forwards-compatible (old versions can open new records, but will discard this field when writing new table versions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Clearing operations now support associating external sequence numbers for improved state tracking during version management.

* **Tests**
  * Added test coverage for sequence number tracking during clear operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->