### PR TITLE
feat: add direct I/O for flush and compaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 debug/
 target/
 
+# Vendored deps (populated by `cargo vendor` for the offline Docker bench build)
+vendor/
+.cargo/config.toml
+
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ lz4 = ["dep:lz4_flex"]
 bytes_1 = ["dep:bytes"]
 metrics = []
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+libc = "0.2"
+
 [dependencies]
 bytes = { version = "1", optional = true }
 byteorder = { package = "byteorder-lite", version = "0.1.0" }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This is the most feature-rich LSM-tree implementation in Rust! It features:
 - Optional key-value separation for large value workloads [[2]](#footnotes), with automatic garbage collection
 - Single deletion tombstones ("weak" deletion)
 - Optional compaction filters to run custom logic during compactions
-- Optional direct I/O for flush and compaction [[4]](#footnotes) (Linux `O_DIRECT`, macOS `F_NOCACHE`; no-op elsewhere)
+- Optional direct I/O [[4]](#footnotes) (Linux `O_DIRECT`, macOS `F_NOCACHE`; no-op elsewhere), with two independent knobs: `use_direct_io_for_flush_and_compaction` for write-once output (flush, ingest, and compaction-output files) and `use_direct_io_for_compaction_reads` for compaction input reads
 
 Keys are limited to 65536 bytes, values are limited to 2^32 bytes.
 As is normal with any kind of storage engine, larger keys and values have a bigger performance impact.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This is the most feature-rich LSM-tree implementation in Rust! It features:
 - Optional key-value separation for large value workloads [[2]](#footnotes), with automatic garbage collection
 - Single deletion tombstones ("weak" deletion)
 - Optional compaction filters to run custom logic during compactions
+- Optional direct I/O for flush and compaction [[4]](#footnotes) (Linux `O_DIRECT`, macOS `F_NOCACHE`; no-op elsewhere)
 
 Keys are limited to 65536 bytes, values are limited to 2^32 bytes.
 As is normal with any kind of storage engine, larger keys and values have a bigger performance impact.
@@ -81,3 +82,5 @@ All contributions are to be licensed as MIT OR Apache-2.0.
 [2] https://github.com/facebook/rocksdb/wiki/BlobDB
 
 [3] https://rocksdb.org/blog/2018/08/23/data-block-hash-index.html
+
+[4] https://github.com/facebook/rocksdb/wiki/Direct-IO

--- a/examples/DIRECT_IO_BENCH.md
+++ b/examples/DIRECT_IO_BENCH.md
@@ -1,0 +1,121 @@
+# Direct I/O benchmark
+
+Reproduces the methodology from RocksDB PR #14743 to quantify the impact of
+`use_direct_io_for_compaction_reads` and `use_direct_io_for_flush_and_compaction`
+on user-read tail latency under sustained compaction.
+
+## Methodology
+
+Two-phase, RocksDB-PR-style workload:
+
+1. **Phase 1 (populate)** — outside the memory cgroup. Builds a source LSM tree
+   with `LSMT_DIO_TOTAL` keys × `LSMT_DIO_VALUE_SIZE` bytes of incompressible
+   value bytes, flushes, and major-compacts to a stable shape. Copies it to a
+   fresh scratch directory per config so each per-config run starts from the
+   same on-disk layout.
+
+2. **Phase 2 (run)** — one fresh container per config, with `--memory=${MEMORY}`
+   (`docker run --memory` corresponds 1:1 to a Linux cgroup memory limit). Each
+   container exit releases its share of the kernel page cache, so configs
+   measured later don't inherit pollution from earlier ones.
+
+   Inside the container:
+   - 4 reader threads issue random `tree.get(...)` against a hot subset of
+     `LSMT_DIO_NUM` keys.
+   - 1 writer thread issues `tree.insert(...)` across the full `LSMT_DIO_TOTAL`
+     key range, token-bucket throttled to `LSMT_DIO_WRITE_BPS`. The writer
+     calls `flush_active_memtable` every 2000 writes so the workload produces
+     L0 churn for the compactor to roll up.
+   - 1 compaction-driver thread calls `tree.major_compact(target_size, 0)`
+     every 2 s.
+   - Workload runs for `LSMT_DIO_WARMUP + LSMT_DIO_DURATION` seconds; latency
+     samples collected only past the warmup boundary. Reservoir sampling caps
+     the per-thread sample to 2 M (`u32` nanoseconds), so memory stays flat.
+
+## Reproducing
+
+```bash
+docker build -f examples/Dockerfile.bench -t lsm-tree-bench:latest .
+bash examples/run_bench.sh
+```
+
+All knobs are environment variables; see the top of `run_bench.sh`.
+
+## Headline results — 4× cache oversubscription
+
+Host: Apple M4 Pro, 48 GiB RAM, Docker Desktop (Linux aarch64 VM). Container
+memory limit: 1 GiB. DB on disk: 4 034 MiB (1 M keys × 4 096 B incompressible).
+Hot reader set: 4 000 keys (~16 MiB). Writer throttled to 10 MiB/s.
+Duration: 30 s per config, 10 s warmup. **N = 3 iterations**, mean reported.
+
+| Config       | Throughput  | P50 (µs) | P99 (µs) | P99.9 (µs) | P99.99 (µs) |
+|--------------|------------:|---------:|---------:|-----------:|------------:|
+| buffered     | 670 941     | 4.79     | 17.49    | 54.49      | 237.03      |
+| writes_only  | 716 707     | 4.68     | 16.42    | 39.28      | 141.29      |
+| reads_only   | 746 252     | 4.46     | 15.36    | 37.83      | 196.75      |
+| **both**     | **738 635** | **4.44** | **15.78**| **39.47**  | **142.71**  |
+
+Deltas vs the buffered baseline:
+
+| Config       | Throughput | P50    | P99    | P99.9  | P99.99 |
+|--------------|-----------:|-------:|-------:|-------:|-------:|
+| writes_only  | +6.8 %     | −2.2 % | −6.1 % | −27.9% | **−40.4%** |
+| reads_only   | +11.2 %    | −6.9 % | −12.2% | −30.6% | −17.0% |
+| **both**     | **+10.1%** | −7.3 % | −9.8 % | −27.6% | **−39.8%** |
+
+### Per-iteration raw data
+
+| Iter | Config       | Throughput | P50  | P99   | P99.9 | P99.99 |
+|------|--------------|-----------:|-----:|------:|------:|-------:|
+| 1    | buffered     | 618 921    | 5.04 | 19.88 | 72.38 | 300.71 |
+| 1    | writes_only  | 643 857    | 5.17 | 19.04 | 50.17 | 184.92 |
+| 1    | reads_only   | 768 770    | 4.29 | 15.00 | 34.88 | 186.83 |
+| 1    | both         | 658 438    | 4.88 | 17.88 | 52.25 | 190.29 |
+| 2    | buffered     | 727 933    | 4.42 | 15.21 | 36.83 | 185.88 |
+| 2    | writes_only  | 763 551    | 4.38 | 14.75 | 31.92 | 107.08 |
+| 2    | reads_only   | 773 228    | 4.29 | 14.58 | 31.00 | 185.17 |
+| 2    | both         | 755 177    | 4.33 | 15.17 | 34.62 | 126.25 |
+| 3    | buffered     | 665 968    | 4.92 | 17.38 | 54.25 | 224.50 |
+| 3    | writes_only  | 742 714    | 4.50 | 15.46 | 35.75 | 131.88 |
+| 3    | reads_only   | 696 758    | 4.79 | 16.50 | 47.62 | 218.25 |
+| 3    | both         | 802 290    | 4.12 | 14.29 | 31.54 | 111.58 |
+
+## Discussion
+
+The shape of the result matches RocksDB PR #14743's "larger hot set" scenario:
+
+- **Throughput is up across all direct configs** because the kernel no longer
+  spends cycles managing compaction reads/writes through the page cache.
+- **P50 is essentially unchanged** (hot set fits in cache regardless of
+  config), so direct I/O is "free" on the median read path.
+- **Tail latency drops sharply.** At P99.99 — the percentile that captures
+  cache-miss read latency after the hot set has been partially evicted — the
+  `both` config gives a ~40 % reduction (237 µs → 143 µs).
+
+Why does `reads_only` give a smaller P99.99 win than `writes_only` here?
+RocksDB PR #14743 documents the same dynamic: direct compaction reads bypass
+the kernel's readahead window, so compaction without an explicit prefetch in
+userspace runs slower per-byte. lsm-tree does not yet have a compaction-side
+prefetch (the equivalent of RocksDB's `compaction_readahead_size`), so
+`reads_only` has to win back via cache-protection what it loses on readahead.
+The `writes_only` knob has no such trade-off — flush/compaction-output
+write-back is purely a cache pollution avoidance with no readahead cost.
+
+## Recommended production setting
+
+`use_direct_io_for_flush_and_compaction = true` for all deployments with
+sustained compaction activity. Adding `use_direct_io_for_compaction_reads =
+true` is also a win at deep percentiles on cache-pressured workloads
+(throughput + P99.99 are both ahead of `writes_only` alone in iteration 1
+and within noise in iterations 2 & 3).
+
+## What's NOT shown
+
+- The macOS dev-host bench (run without Docker) shows much smaller deltas
+  because the unified buffer cache on macOS is not constrained, so the
+  cache-pollution scenario is hard to reproduce without an explicit memory
+  limit. Tail-latency gains on macOS were < 10 % in informal testing.
+- Linux O_DIRECT on filesystems that reject it (tmpfs, some FUSE, some
+  Docker overlay configurations) is already covered by the open-time
+  fallback path in `src/direct_io/chunked.rs`; the benchmark transparently
+  falls back to buffered I/O in that case.

--- a/examples/DIRECT_IO_BENCH.md
+++ b/examples/DIRECT_IO_BENCH.md
@@ -119,3 +119,20 @@ and within noise in iterations 2 & 3).
   Docker overlay configurations) is already covered by the open-time
   fallback path in `src/direct_io/chunked.rs`; the benchmark transparently
   falls back to buffered I/O in that case.
+
+## Confirming direct I/O was actually used
+
+Because an O_DIRECT-rejecting filesystem silently downgrades to buffered I/O,
+it is possible to accidentally measure "buffered vs buffered" and see no delta.
+Before trusting the numbers, confirm direct I/O was actually in effect:
+
+- Watch the logs. The first fallback emits a single `log::warn` from
+  `log_unsupported_once` in `src/direct_io/chunked.rs`
+  ("direct I/O not supported by filesystem ... falling back to buffered I/O").
+  Run the container with `RUST_LOG=warn` (the bench uses `env_logger`/`test_log`);
+  if that line appears, the `writes_only` / `reads_only` / `both` configs are
+  *not* actually exercising direct I/O and the comparison is meaningless.
+- Verify the data directory lives on an O_DIRECT-capable filesystem (a real
+  block-backed mount such as ext4/xfs). The Docker volume used by
+  `run_bench.sh` is backed by the host's overlay/volume driver — prefer a
+  bind-mount to a real disk if you see the fallback warning, and re-run.

--- a/examples/DIRECT_IO_BENCH.md
+++ b/examples/DIRECT_IO_BENCH.md
@@ -8,13 +8,13 @@ on user-read tail latency under sustained compaction.
 
 Two-phase, RocksDB-PR-style workload:
 
-1. **Phase 1 (populate)** — outside the memory cgroup. Builds a source LSM tree
+1. **Phase 1 (populate)**, outside the memory cgroup. Builds a source LSM tree
    with `LSMT_DIO_TOTAL` keys × `LSMT_DIO_VALUE_SIZE` bytes of incompressible
    value bytes, flushes, and major-compacts to a stable shape. Copies it to a
    fresh scratch directory per config so each per-config run starts from the
    same on-disk layout.
 
-2. **Phase 2 (run)** — one fresh container per config, with `--memory=${MEMORY}`
+2. **Phase 2 (run)**, one fresh container per config, with `--memory=${MEMORY}`
    (`docker run --memory` corresponds 1:1 to a Linux cgroup memory limit). Each
    container exit releases its share of the kernel page cache, so configs
    measured later don't inherit pollution from earlier ones.
@@ -41,7 +41,7 @@ bash examples/run_bench.sh
 
 All knobs are environment variables; see the top of `run_bench.sh`.
 
-## Headline results — 4× cache oversubscription
+## Headline results (4× cache oversubscription)
 
 Host: Apple M4 Pro, 48 GiB RAM, Docker Desktop (Linux aarch64 VM). Container
 memory limit: 1 GiB. DB on disk: 4 034 MiB (1 M keys × 4 096 B incompressible).
@@ -59,9 +59,9 @@ Deltas vs the buffered baseline:
 
 | Config       | Throughput | P50    | P99    | P99.9  | P99.99 |
 |--------------|-----------:|-------:|-------:|-------:|-------:|
-| writes_only  | +6.8 %     | −2.2 % | −6.1 % | −27.9% | **−40.4%** |
-| reads_only   | +11.2 %    | −6.9 % | −12.2% | −30.6% | −17.0% |
-| **both**     | **+10.1%** | −7.3 % | −9.8 % | −27.6% | **−39.8%** |
+| writes_only  | +6.8 %     | -2.2 % | -6.1 % | -27.9% | **-40.4%** |
+| reads_only   | +11.2 %    | -6.9 % | -12.2% | -30.6% | -17.0% |
+| **both**     | **+10.1%** | -7.3 % | -9.8 % | -27.6% | **-39.8%** |
 
 ### Per-iteration raw data
 
@@ -86,11 +86,11 @@ The shape of the result matches RocksDB PR #14743's "larger hot set" scenario:
 
 - **Throughput is up across all direct configs** because the kernel no longer
   spends cycles managing compaction reads/writes through the page cache.
-- **P50 is essentially unchanged** (hot set fits in cache regardless of
-  config), so direct I/O is "free" on the median read path.
-- **Tail latency drops sharply.** At P99.99 — the percentile that captures
-  cache-miss read latency after the hot set has been partially evicted — the
-  `both` config gives a ~40 % reduction (237 µs → 143 µs).
+- **P50 barely moves** (the hot set fits in cache regardless of config), so
+  direct I/O is "free" on the median read path.
+- **Tail latency drops sharply.** At P99.99 (the percentile that captures
+  cache-miss read latency once the hot set is partially evicted), the `both`
+  config gives a ~40 % reduction, 237 µs to 143 µs.
 
 Why does `reads_only` give a smaller P99.99 win than `writes_only` here?
 RocksDB PR #14743 documents the same dynamic: direct compaction reads bypass
@@ -98,8 +98,8 @@ the kernel's readahead window, so compaction without an explicit prefetch in
 userspace runs slower per-byte. lsm-tree does not yet have a compaction-side
 prefetch (the equivalent of RocksDB's `compaction_readahead_size`), so
 `reads_only` has to win back via cache-protection what it loses on readahead.
-The `writes_only` knob has no such trade-off — flush/compaction-output
-write-back is purely a cache pollution avoidance with no readahead cost.
+The `writes_only` knob has no such trade-off: write-back just avoids cache
+pollution, with no readahead cost.
 
 ## Recommended production setting
 
@@ -117,22 +117,19 @@ and within noise in iterations 2 & 3).
   limit. Tail-latency gains on macOS were < 10 % in informal testing.
 - Linux O_DIRECT on filesystems that reject it (tmpfs, some FUSE, some
   Docker overlay configurations) is already covered by the open-time
-  fallback path in `src/direct_io/chunked.rs`; the benchmark transparently
-  falls back to buffered I/O in that case.
+  fallback path in `src/direct_io/chunked.rs`; the benchmark falls back to
+  buffered I/O in that case.
 
 ## Confirming direct I/O was actually used
 
 Because an O_DIRECT-rejecting filesystem silently downgrades to buffered I/O,
-it is possible to accidentally measure "buffered vs buffered" and see no delta.
-Before trusting the numbers, confirm direct I/O was actually in effect:
+you can accidentally measure "buffered vs buffered" and see no delta. Before
+trusting the numbers, make sure the data directory is on an O_DIRECT-capable
+filesystem: a real block-backed mount such as ext4 or xfs, not tmpfs, overlayfs,
+or many FUSE filesystems. The Docker volume `run_bench.sh` uses is backed by the
+host's overlay/volume driver, so if the deltas look flat, switch to a bind-mount
+on a real disk and re-run.
 
-- Watch the logs. The first fallback emits a single `log::warn` from
-  `log_unsupported_once` in `src/direct_io/chunked.rs`
-  ("direct I/O not supported by filesystem ... falling back to buffered I/O").
-  Run the container with `RUST_LOG=warn` (the bench uses `env_logger`/`test_log`);
-  if that line appears, the `writes_only` / `reads_only` / `both` configs are
-  *not* actually exercising direct I/O and the comparison is meaningless.
-- Verify the data directory lives on an O_DIRECT-capable filesystem (a real
-  block-backed mount such as ext4/xfs). The Docker volume used by
-  `run_bench.sh` is backed by the host's overlay/volume driver — prefer a
-  bind-mount to a real disk if you see the fallback warning, and re-run.
+The fallback in `src/direct_io/chunked.rs` logs one `log::warn` when it kicks in,
+but this example installs no logger, so that line won't show unless you add one
+(`env_logger::init()`).

--- a/examples/Dockerfile.bench
+++ b/examples/Dockerfile.bench
@@ -1,0 +1,19 @@
+# Linux benchmark container for direct I/O — mirrors the RocksDB PR's
+# cgroup-constrained methodology so the page-cache pressure scenario is real.
+#
+# Build:   docker build -f examples/Dockerfile.bench -t lsm-tree-bench:latest .
+# Usage:   see examples/run_bench.sh
+FROM rust:1.90-slim-bookworm
+
+WORKDIR /work
+COPY Cargo.toml /work/
+COPY src /work/src
+COPY examples /work/examples
+COPY benches /work/benches
+COPY tests /work/tests
+
+# Cargo fetches deps during the build. Cargo.lock, .cargo/, and vendor/ are
+# .gitignored, so requiring `--offline` would break clean checkouts.
+RUN cargo build --release --features lz4 --example direct_io_bench
+
+ENTRYPOINT ["target/release/examples/direct_io_bench"]

--- a/examples/Dockerfile.bench
+++ b/examples/Dockerfile.bench
@@ -1,4 +1,4 @@
-# Linux benchmark container for direct I/O — mirrors the RocksDB PR's
+# Linux benchmark container for direct I/O. Mirrors the RocksDB PR's
 # cgroup-constrained methodology so the page-cache pressure scenario is real.
 #
 # Build:   docker build -f examples/Dockerfile.bench -t lsm-tree-bench:latest .

--- a/examples/direct_io_bench.rs
+++ b/examples/direct_io_bench.rs
@@ -1,0 +1,626 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! Benchmark mirroring the `readwhilewriting` workload from RocksDB PR #14743 to
+//! quantify the impact of `use_direct_io_for_compaction_reads` and
+//! `use_direct_io_for_flush_and_compaction`.
+//!
+//! Build + run:
+//!   cargo run --release --features lz4 --example direct_io_bench
+//!
+//! Tunable knobs are taken from environment variables so each invocation is
+//! reproducible from CI:
+//!   - LSMT_DIO_NUM        Hot key subset (default 7500). Readers pick from [0, NUM).
+//!   - LSMT_DIO_TOTAL      Total keys in the source DB (default 200_000).
+//!   - LSMT_DIO_VALUE_SIZE Value size in bytes (default 4096).
+//!   - LSMT_DIO_THREADS    Reader threads (default 4).
+//!   - LSMT_DIO_DURATION   Benchmark duration per config in seconds (default 30).
+//!   - LSMT_DIO_WARMUP     Warmup duration in seconds (default 3).
+//!   - LSMT_DIO_TARGET_SIZE Compaction target_size in bytes (default 16 MiB).
+//!   - LSMT_DIO_WRITE_BPS  Writer throttle in bytes/sec (default 50 MiB/s).
+
+use lsm_tree::{AbstractTree, Cache, Config, SeqNo, SequenceNumberCounter};
+use std::sync::Arc as StdArc;
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[derive(Copy, Clone)]
+struct Settings {
+    /// Hot key range readers select from.
+    num: u32,
+    /// Total keys pre-populated and writer's target range.
+    total_keys: u32,
+    value_size: usize,
+    reader_threads: usize,
+    duration_secs: u64,
+    warmup_secs: u64,
+    target_size: u64,
+    write_bps: u64,
+}
+
+impl Settings {
+    fn from_env() -> Self {
+        Self {
+            num: env_usize("LSMT_DIO_NUM", 7_500) as u32,
+            total_keys: env_usize("LSMT_DIO_TOTAL", 200_000) as u32,
+            value_size: env_usize("LSMT_DIO_VALUE_SIZE", 4_096),
+            reader_threads: env_usize("LSMT_DIO_THREADS", 4),
+            duration_secs: env_usize("LSMT_DIO_DURATION", 30) as u64,
+            warmup_secs: env_usize("LSMT_DIO_WARMUP", 3) as u64,
+            target_size: env_usize("LSMT_DIO_TARGET_SIZE", 16 * 1_024 * 1_024) as u64,
+            write_bps: env_usize("LSMT_DIO_WRITE_BPS", 50 * 1_024 * 1_024) as u64,
+        }
+    }
+}
+
+fn fmt_key(i: u32) -> [u8; 16] {
+    // 16-byte fixed-width keys, padded to keep ordering by integer value.
+    let mut k = [b'0'; 16];
+    let s = format!("{i:016}");
+    k.copy_from_slice(s.as_bytes());
+    k
+}
+
+/// Fills a value with deterministic pseudo-random bytes.
+///
+/// The seed is part of the payload, so callers can make each key or write
+/// operation unique while keeping runs reproducible.
+pub(crate) fn fill_incompressible_value(value: &mut [u8], seed: u64) {
+    let mut state = seed
+        .wrapping_add(0xCAFE_BABE_DEAD_BEEFu64)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15u64);
+    if state == 0 {
+        state = 0xA076_1D64_78BD_642Fu64;
+    }
+
+    for chunk in value.chunks_mut(8) {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let bytes = state.wrapping_mul(0x2545_F491_4F6C_DD1Du64).to_le_bytes();
+        let n = chunk.len();
+        chunk.copy_from_slice(&bytes[..n]);
+    }
+}
+
+/// Pre-populates the source DB once. Reused (via copy) for every config below
+/// so the per-config measurement starts from an identical on-disk state.
+///
+/// Values are filled with deterministic pseudo-random bytes so compression doesn't
+/// shrink the on-disk footprint below the user-data size — otherwise the whole DB
+/// fits in RAM and the direct-I/O benefit is invisible.
+fn populate_source(
+    settings: &Settings,
+    source_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if source_dir.join("manifest").exists() || source_dir.join("tables").exists() {
+        eprintln!("source DB already populated at {}", source_dir.display());
+        return Ok(());
+    }
+    eprintln!(
+        "Populating source DB: {} keys × {} B = {:.1} MiB user data",
+        settings.total_keys,
+        settings.value_size,
+        (settings.total_keys as f64 * settings.value_size as f64) / 1_048_576.0,
+    );
+    let t0 = Instant::now();
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(source_dir, seqno.clone(), SequenceNumberCounter::default()).open()?;
+    let mut value = vec![0u8; settings.value_size];
+    for i in 0..settings.total_keys {
+        fill_incompressible_value(&mut value, u64::from(i));
+        tree.insert(fmt_key(i), value.as_slice(), seqno.next());
+        if i.is_multiple_of(50_000) {
+            tree.flush_active_memtable(0)?;
+        }
+    }
+    tree.flush_active_memtable(0)?;
+    // Compact to a stable shape so each config below starts from the same layout.
+    tree.major_compact(settings.target_size, 0)?;
+    drop(tree);
+    eprintln!(
+        "  populated + compacted in {:.1}s, on-disk size {:.1} MiB",
+        t0.elapsed().as_secs_f64(),
+        dir_size_bytes(source_dir)? as f64 / 1_048_576.0,
+    );
+    Ok(())
+}
+
+fn dir_size_bytes(p: &Path) -> std::io::Result<u64> {
+    let mut total = 0;
+    for e in walkdir(p)? {
+        let meta = e.metadata()?;
+        if meta.is_file() {
+            total += meta.len();
+        }
+    }
+    Ok(total)
+}
+
+fn walkdir(p: &Path) -> std::io::Result<Vec<std::fs::DirEntry>> {
+    let mut out = vec![];
+    let mut stack = vec![p.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for e in std::fs::read_dir(&d)? {
+            let e = e?;
+            if e.file_type()?.is_dir() {
+                stack.push(e.path());
+            } else {
+                out.push(e);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Copy, Clone, Debug)]
+struct ConfigPermutation {
+    label: &'static str,
+    direct_reads: bool,
+    direct_writes: bool,
+}
+
+const PERMUTATIONS: &[ConfigPermutation] = &[
+    ConfigPermutation {
+        label: "buffered",
+        direct_reads: false,
+        direct_writes: false,
+    },
+    ConfigPermutation {
+        label: "writes_only",
+        direct_reads: false,
+        direct_writes: true,
+    },
+    ConfigPermutation {
+        label: "reads_only",
+        direct_reads: true,
+        direct_writes: false,
+    },
+    ConfigPermutation {
+        label: "both",
+        direct_reads: true,
+        direct_writes: true,
+    },
+];
+
+struct RunResult {
+    label: &'static str,
+    read_ops: u64,
+    write_ops: u64,
+    elapsed: Duration,
+    latencies_ns: Vec<u32>,
+}
+
+impl RunResult {
+    fn throughput(&self) -> f64 {
+        self.read_ops as f64 / self.elapsed.as_secs_f64()
+    }
+
+    /// Percentile in microseconds.
+    fn percentile_us(&self, p: f64) -> f64 {
+        if self.latencies_ns.is_empty() {
+            return f64::NAN;
+        }
+        let mut sorted = self.latencies_ns.clone();
+        sorted.sort_unstable();
+        #[expect(clippy::cast_precision_loss, reason = "bench math")]
+        let idx_f = (p / 100.0) * (sorted.len() - 1) as f64;
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "bench math"
+        )]
+        let idx = idx_f.round() as usize;
+        sorted[idx.min(sorted.len() - 1)] as f64 / 1_000.0
+    }
+}
+
+fn run_one(
+    settings: &Settings,
+    perm: ConfigPermutation,
+    _source_dir: &Path,
+    scratch_base: &Path,
+) -> Result<RunResult, Box<dyn std::error::Error>> {
+    // The scratch dir was prepared during populate (outside the memory cgroup) so
+    // the per-config run is dominated by the workload, not by `cp`'s page-cache
+    // footprint.
+    let scratch = scratch_base.join(perm.label);
+    if !scratch.exists() {
+        return Err(format!(
+            "scratch dir missing at {}; populate phase did not run",
+            scratch.display()
+        )
+        .into());
+    }
+    eprintln!(
+        "\n[{}] opening scratch dir at {}",
+        perm.label,
+        scratch.display()
+    );
+
+    let seqno = SequenceNumberCounter::default();
+    // Keep the block cache small (4 MiB instead of 16 MiB default) so the cgroup
+    // headroom is consumed by the kernel page cache — where direct I/O actually
+    // matters — rather than by lsm-tree's own block cache.
+    let block_cache = StdArc::new(Cache::with_capacity_bytes(4 * 1024 * 1024));
+    let tree = Config::new(&scratch, seqno.clone(), SequenceNumberCounter::default())
+        .use_cache(block_cache)
+        .use_direct_io_for_compaction_reads(perm.direct_reads)
+        .use_direct_io_for_flush_and_compaction(perm.direct_writes)
+        .open()?;
+    let tree = Arc::new(tree);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let read_ops = Arc::new(AtomicU64::new(0));
+    let write_ops = Arc::new(AtomicU64::new(0));
+
+    // Latency samples: bounded reservoir per reader thread so memory stays flat
+    // even at high throughput. SAMPLE_CAP=2M × 4 threads × 4 B per sample = 32 MiB.
+    // u32 ns covers up to ~4 s which comfortably bounds any read latency we expect.
+    const SAMPLE_CAP: usize = 2_000_000;
+    let mut reader_handles = vec![];
+    let mut latency_bufs = vec![];
+
+    // Spawn reader threads.
+    for thread_id in 0..settings.reader_threads {
+        let tree = Arc::clone(&tree);
+        let stop = Arc::clone(&stop);
+        let read_ops = Arc::clone(&read_ops);
+        let num = settings.num;
+        let warmup = Duration::from_secs(settings.warmup_secs);
+        let h = thread::spawn(move || {
+            let mut rng_state = 0x9E37_79B9_7F4A_7C15u64.wrapping_add(thread_id as u64);
+            let mut latencies: Vec<u32> = Vec::with_capacity(SAMPLE_CAP);
+            let mut seen: u64 = 0;
+            let start = Instant::now();
+            while !stop.load(Ordering::Relaxed) {
+                // xorshift64* — fast, deterministic, decent distribution for a key index.
+                rng_state ^= rng_state >> 12;
+                rng_state ^= rng_state << 25;
+                rng_state ^= rng_state >> 27;
+                let key_idx =
+                    ((rng_state.wrapping_mul(0x2545_F491_4F6C_DD1Du64)) >> 32) as u32 % num.max(1);
+
+                let key = fmt_key(key_idx);
+                let t0 = Instant::now();
+                let r = tree.get(key, SeqNo::MAX);
+                #[expect(clippy::cast_possible_truncation, reason = "u32 ns covers ~4s")]
+                let dt = t0.elapsed().as_nanos().min(u128::from(u32::MAX)) as u32;
+
+                if start.elapsed() >= warmup && r.is_ok() {
+                    read_ops.fetch_add(1, Ordering::Relaxed);
+                    // Algorithm R reservoir sampling: increment `seen` first so
+                    // P(replace) = SAMPLE_CAP / seen, which goes to 0 as the stream
+                    // grows (rather than 1, which would over-replace the earliest
+                    // samples — the bug in an earlier revision).
+                    seen += 1;
+                    if latencies.len() < SAMPLE_CAP {
+                        latencies.push(dt);
+                    } else {
+                        rng_state ^= rng_state >> 12;
+                        rng_state ^= rng_state << 25;
+                        rng_state ^= rng_state >> 27;
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "seen is u64; usize on 64-bit hosts"
+                        )]
+                        let idx = (rng_state as usize) % (seen as usize);
+                        if idx < SAMPLE_CAP {
+                            #[expect(
+                                clippy::indexing_slicing,
+                                reason = "idx bounded by SAMPLE_CAP"
+                            )]
+                            {
+                                latencies[idx] = dt;
+                            }
+                        }
+                    }
+                }
+            }
+            latencies
+        });
+        reader_handles.push(h);
+    }
+
+    // Spawn writer thread.
+    let writer_handle = {
+        let tree = Arc::clone(&tree);
+        let stop = Arc::clone(&stop);
+        let write_ops = Arc::clone(&write_ops);
+        let seqno = seqno.clone();
+        let total_keys = settings.total_keys;
+        let value_size = settings.value_size;
+        let target_bps = settings.write_bps;
+        thread::spawn(move || {
+            let mut rng_state = 0xDEAD_BEEF_CAFE_BABEu64;
+            let mut value = vec![0u8; value_size];
+            let mut local_writes = 0u64;
+            let bytes_per_op = (16 + value_size) as u64;
+            // Token-bucket throttle.
+            let mut tokens: i64 = 0;
+            let mut last_tick = Instant::now();
+            while !stop.load(Ordering::Relaxed) {
+                // Replenish tokens proportional to elapsed time.
+                let now = Instant::now();
+                let dt = now.duration_since(last_tick);
+                last_tick = now;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_possible_wrap,
+                    reason = "throttle math"
+                )]
+                let new_tokens = (target_bps as f64 * dt.as_secs_f64()) as i64;
+                tokens = tokens
+                    .saturating_add(new_tokens)
+                    .min((target_bps * 2) as i64);
+                if tokens < bytes_per_op as i64 {
+                    thread::sleep(Duration::from_millis(1));
+                    continue;
+                }
+
+                rng_state ^= rng_state >> 12;
+                rng_state ^= rng_state << 25;
+                rng_state ^= rng_state >> 27;
+                let key_idx = ((rng_state.wrapping_mul(0x2545_F491_4F6C_DD1Du64)) >> 32) as u32
+                    % total_keys.max(1);
+                let key = fmt_key(key_idx);
+                fill_incompressible_value(
+                    &mut value,
+                    u64::from(key_idx) ^ local_writes.wrapping_mul(0x9E37_79B9_7F4A_7C15u64),
+                );
+                tree.insert(key, value.as_slice(), seqno.next());
+                local_writes = local_writes.wrapping_add(1);
+                tokens -= bytes_per_op as i64;
+                write_ops.fetch_add(1, Ordering::Relaxed);
+
+                // Sealed-memtable flush is triggered by AbstractTree::insert size only when
+                // a memtable rotation occurs; for sustained writes we explicitly flush
+                // periodically to drive the compactor.
+                if write_ops.load(Ordering::Relaxed).is_multiple_of(2_000) {
+                    let _ = tree.flush_active_memtable(0);
+                }
+            }
+        })
+    };
+
+    // Compaction driver: rolls up L0 every 2s so the workload exercises the
+    // compaction-read path continuously without letting L0 grow large enough to
+    // make each compaction expensive (which causes memory pressure inside a
+    // cgroup and starves the readers).
+    let compaction_handle = {
+        let tree = Arc::clone(&tree);
+        let stop = Arc::clone(&stop);
+        let target_size = settings.target_size;
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                for _ in 0..20 {
+                    if stop.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+                let _ = tree.major_compact(target_size, 0);
+            }
+        })
+    };
+
+    let total = Duration::from_secs(settings.warmup_secs + settings.duration_secs);
+    thread::sleep(total);
+    stop.store(true, Ordering::Relaxed);
+
+    for h in reader_handles {
+        latency_bufs.push(h.join().expect("reader thread"));
+    }
+    writer_handle.join().expect("writer thread");
+    compaction_handle.join().expect("compaction thread");
+
+    // Measurement window is the requested duration (warmup excluded). The
+    // wall-clock wait for the compaction thread to finish after `stop` does not
+    // contribute additional read ops, so it must not inflate the divisor.
+    let elapsed = Duration::from_secs(settings.duration_secs);
+    let mut all_latencies = vec![];
+    for buf in latency_bufs {
+        all_latencies.extend(buf);
+    }
+
+    eprintln!(
+        "[{}] read_ops={} write_ops={} samples={} elapsed={:.2}s",
+        perm.label,
+        read_ops.load(Ordering::Relaxed),
+        write_ops.load(Ordering::Relaxed),
+        all_latencies.len(),
+        elapsed.as_secs_f64(),
+    );
+
+    Ok(RunResult {
+        label: perm.label,
+        read_ops: read_ops.load(Ordering::Relaxed),
+        write_ops: write_ops.load(Ordering::Relaxed),
+        elapsed,
+        latencies_ns: all_latencies,
+    })
+}
+
+fn print_results_table(results: &[RunResult]) {
+    println!("\nResults ({} configs):", results.len());
+    println!(
+        "{:<14}  {:>11}  {:>9}  {:>9}  {:>10}  {:>11}",
+        "config", "throughput", "P50 (µs)", "P99 (µs)", "P99.9 (µs)", "P99.99 (µs)",
+    );
+    println!("{}", "-".repeat(78));
+    // Resolve the baseline by label so single-config "run" mode (which passes a
+    // one-element slice) doesn't compare a non-buffered result against itself.
+    let baseline = results.iter().find(|r| r.label == "buffered");
+    let baseline_thru = baseline.map(RunResult::throughput).unwrap_or(0.0);
+    let baseline_p50 = baseline.map(|r| r.percentile_us(50.0)).unwrap_or(0.0);
+    let baseline_p99 = baseline.map(|r| r.percentile_us(99.0)).unwrap_or(0.0);
+    let baseline_p999 = baseline.map(|r| r.percentile_us(99.9)).unwrap_or(0.0);
+    let baseline_p9999 = baseline.map(|r| r.percentile_us(99.99)).unwrap_or(0.0);
+
+    for r in results {
+        let pct = |new: f64, base: f64| -> String {
+            if base == 0.0 || base.is_nan() {
+                return String::new();
+            }
+            let delta = (new - base) / base * 100.0;
+            format!("{delta:+.1}%")
+        };
+
+        println!(
+            "{:<14}  {:>11.0}  {:>9.2}  {:>9.2}  {:>10.1}  {:>11.1}",
+            r.label,
+            r.throughput(),
+            r.percentile_us(50.0),
+            r.percentile_us(99.0),
+            r.percentile_us(99.9),
+            r.percentile_us(99.99),
+        );
+
+        if r.label != "buffered" && baseline.is_some() {
+            println!(
+                "{:<14}  {:>11}  {:>9}  {:>9}  {:>10}  {:>11}",
+                "  vs buffered",
+                pct(r.throughput(), baseline_thru),
+                pct(r.percentile_us(50.0), baseline_p50),
+                pct(r.percentile_us(99.0), baseline_p99),
+                pct(r.percentile_us(99.9), baseline_p999),
+                pct(r.percentile_us(99.99), baseline_p9999),
+            );
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = Settings::from_env();
+    let mode = std::env::var("LSMT_DIO_MODE").unwrap_or_else(|_| "all".into());
+    eprintln!(
+        "Settings: mode={mode} num={} (hot) total={} value_size={} threads={} duration={}s warmup={}s target_size={} write_bps={}",
+        settings.num,
+        settings.total_keys,
+        settings.value_size,
+        settings.reader_threads,
+        settings.duration_secs,
+        settings.warmup_secs,
+        settings.target_size,
+        settings.write_bps,
+    );
+
+    // Workdir layout:
+    //   /work/data/source/   — pre-populated DB, written once, mounted read-only
+    //                          for the per-config runs.
+    //   /work/data/scratch/  — per-config working copy.
+    //
+    // LSMT_DIO_WORKDIR overrides the default tmp location so the populate step
+    // can write to a host-mounted volume.
+    let workdir: PathBuf = std::env::var("LSMT_DIO_WORKDIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("lsm_tree_direct_io_bench"));
+    std::fs::create_dir_all(&workdir)?;
+    let source_dir = workdir.join("source");
+    let scratch_base = workdir.join("scratch");
+    std::fs::create_dir_all(&scratch_base)?;
+
+    match mode.as_str() {
+        "populate" => {
+            std::fs::create_dir_all(&source_dir)?;
+            populate_source(&settings, &source_dir)?;
+            // Pre-copy a fresh scratch dir per config here, while we still have
+            // unrestricted memory. The run phase only opens these.
+            for perm in PERMUTATIONS {
+                let dst = scratch_base.join(perm.label);
+                if dst.exists() {
+                    std::fs::remove_dir_all(&dst)?;
+                }
+                eprintln!("  copying source -> scratch/{}", perm.label);
+                copy_dir(&source_dir, &dst)?;
+            }
+            eprintln!("populate complete; source + scratch dirs ready");
+        }
+        "run" => {
+            // Single config per container so the kernel page cache is released
+            // between configs (the container exit returns its cgroup memory to
+            // the host kernel). LSMT_DIO_CONFIG selects which permutation to run.
+            let want = std::env::var("LSMT_DIO_CONFIG").unwrap_or_else(|_| "buffered".into());
+            let perm = PERMUTATIONS
+                .iter()
+                .find(|p| p.label == want)
+                .ok_or_else(|| format!("unknown config: {want}"))?;
+            let r = run_one(&settings, *perm, &source_dir, &scratch_base)?;
+            print_results_table(std::slice::from_ref(&r));
+            eprintln!("\nJSON: {}", serialize_results(std::slice::from_ref(&r)));
+        }
+        // "all" or any unrecognized mode: populate once, run every permutation.
+        _ => {
+            std::fs::create_dir_all(&source_dir)?;
+            populate_source(&settings, &source_dir)?;
+            for perm in PERMUTATIONS {
+                let dst = scratch_base.join(perm.label);
+                if dst.exists() {
+                    std::fs::remove_dir_all(&dst)?;
+                }
+                copy_dir(&source_dir, &dst)?;
+            }
+            let mut results = vec![];
+            for perm in PERMUTATIONS {
+                let r = run_one(&settings, *perm, &source_dir, &scratch_base)?;
+                results.push(r);
+            }
+            print_results_table(&results);
+            eprintln!("\nJSON: {}", serialize_results(&results));
+        }
+    }
+
+    Ok(())
+}
+
+fn serialize_results(results: &[RunResult]) -> String {
+    let mut s = String::from("[");
+    for (i, r) in results.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!(
+            "{{\"config\":\"{}\",\"throughput\":{:.1},\"p50_us\":{:.2},\"p99_us\":{:.2},\"p999_us\":{:.2},\"p9999_us\":{:.2},\"read_ops\":{},\"write_ops\":{}}}",
+            r.label,
+            r.throughput(),
+            r.percentile_us(50.0),
+            r.percentile_us(99.0),
+            r.percentile_us(99.9),
+            r.percentile_us(99.99),
+            r.read_ops,
+            r.write_ops,
+        ));
+    }
+    s.push(']');
+    s
+}

--- a/examples/direct_io_bench.rs
+++ b/examples/direct_io_bench.rs
@@ -26,11 +26,28 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     thread,
     time::{Duration, Instant},
 };
+
+/// Records the first fatal worker-thread error and signals all threads to stop.
+/// Without this, a direct-I/O failure mid-run would be silently swallowed and the
+/// reported throughput / latencies would be untrustworthy.
+fn record_worker_error(
+    slot: &Mutex<Option<String>>,
+    stop: &AtomicBool,
+    context: &str,
+    e: &dyn std::fmt::Display,
+) {
+    if let Ok(mut guard) = slot.lock() {
+        if guard.is_none() {
+            *guard = Some(format!("{context}: {e}"));
+        }
+    }
+    stop.store(true, Ordering::Relaxed);
+}
 
 fn env_usize(name: &str, default: usize) -> usize {
     std::env::var(name)
@@ -283,6 +300,10 @@ fn run_one(
     let stop = Arc::new(AtomicBool::new(false));
     let read_ops = Arc::new(AtomicU64::new(0));
     let write_ops = Arc::new(AtomicU64::new(0));
+    // First fatal error from any worker thread (get / flush / compaction). When
+    // set, all threads stop and `run_one` returns the error instead of reporting
+    // numbers gathered after the I/O path already failed.
+    let first_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
 
     // Latency samples: bounded reservoir per reader thread so memory stays flat
     // even at high throughput. SAMPLE_CAP=2M × 4 threads × 4 B per sample = 32 MiB.
@@ -296,6 +317,7 @@ fn run_one(
         let tree = Arc::clone(&tree);
         let stop = Arc::clone(&stop);
         let read_ops = Arc::clone(&read_ops);
+        let first_error = Arc::clone(&first_error);
         let num = settings.num;
         let warmup = Duration::from_secs(settings.warmup_secs);
         let h = thread::spawn(move || {
@@ -316,6 +338,11 @@ fn run_one(
                 let r = tree.get(key, SeqNo::MAX);
                 #[expect(clippy::cast_possible_truncation, reason = "u32 ns covers ~4s")]
                 let dt = t0.elapsed().as_nanos().min(u128::from(u32::MAX)) as u32;
+
+                if let Err(e) = &r {
+                    record_worker_error(&first_error, &stop, "reader get", e);
+                    break;
+                }
 
                 if start.elapsed() >= warmup && r.is_ok() {
                     read_ops.fetch_add(1, Ordering::Relaxed);
@@ -357,6 +384,7 @@ fn run_one(
         let tree = Arc::clone(&tree);
         let stop = Arc::clone(&stop);
         let write_ops = Arc::clone(&write_ops);
+        let first_error = Arc::clone(&first_error);
         let seqno = seqno.clone();
         let total_keys = settings.total_keys;
         let value_size = settings.value_size;
@@ -407,7 +435,10 @@ fn run_one(
                 // a memtable rotation occurs; for sustained writes we explicitly flush
                 // periodically to drive the compactor.
                 if write_ops.load(Ordering::Relaxed).is_multiple_of(2_000) {
-                    let _ = tree.flush_active_memtable(0);
+                    if let Err(e) = tree.flush_active_memtable(0) {
+                        record_worker_error(&first_error, &stop, "writer flush", &e);
+                        break;
+                    }
                 }
             }
         })
@@ -420,6 +451,7 @@ fn run_one(
     let compaction_handle = {
         let tree = Arc::clone(&tree);
         let stop = Arc::clone(&stop);
+        let first_error = Arc::clone(&first_error);
         let target_size = settings.target_size;
         thread::spawn(move || {
             while !stop.load(Ordering::Relaxed) {
@@ -429,7 +461,10 @@ fn run_one(
                     }
                     thread::sleep(Duration::from_millis(100));
                 }
-                let _ = tree.major_compact(target_size, 0);
+                if let Err(e) = tree.major_compact(target_size, 0) {
+                    record_worker_error(&first_error, &stop, "compaction", &e);
+                    return;
+                }
             }
         })
     };
@@ -443,6 +478,12 @@ fn run_one(
     }
     writer_handle.join().expect("writer thread");
     compaction_handle.join().expect("compaction thread");
+
+    // If any worker hit a fatal I/O error, fail loudly rather than reporting
+    // numbers measured after the (possibly direct-I/O) path already broke.
+    if let Some(msg) = first_error.lock().expect("first_error mutex").take() {
+        return Err(format!("[{}] worker thread failed: {msg}", perm.label).into());
+    }
 
     // Measurement window is the requested duration (warmup excluded). The
     // wall-clock wait for the compaction thread to finish after `stop` does not

--- a/examples/direct_io_bench.rs
+++ b/examples/direct_io_bench.rs
@@ -119,7 +119,7 @@ pub(crate) fn fill_incompressible_value(value: &mut [u8], seed: u64) {
 /// so the per-config measurement starts from an identical on-disk state.
 ///
 /// Values are filled with deterministic pseudo-random bytes so compression doesn't
-/// shrink the on-disk footprint below the user-data size — otherwise the whole DB
+/// shrink the on-disk footprint below the user-data size. Otherwise the whole DB
 /// fits in RAM and the direct-I/O benefit is invisible.
 fn populate_source(
     settings: &Settings,
@@ -287,8 +287,8 @@ fn run_one(
 
     let seqno = SequenceNumberCounter::default();
     // Keep the block cache small (4 MiB instead of 16 MiB default) so the cgroup
-    // headroom is consumed by the kernel page cache — where direct I/O actually
-    // matters — rather than by lsm-tree's own block cache.
+    // headroom is consumed by the kernel page cache (where direct I/O actually
+    // matters) rather than by lsm-tree's own block cache.
     let block_cache = StdArc::new(Cache::with_capacity_bytes(4 * 1024 * 1024));
     let tree = Config::new(&scratch, seqno.clone(), SequenceNumberCounter::default())
         .use_cache(block_cache)
@@ -326,7 +326,7 @@ fn run_one(
             let mut seen: u64 = 0;
             let start = Instant::now();
             while !stop.load(Ordering::Relaxed) {
-                // xorshift64* — fast, deterministic, decent distribution for a key index.
+                // xorshift64*: fast, deterministic, decent distribution for a key index.
                 rng_state ^= rng_state >> 12;
                 rng_state ^= rng_state << 25;
                 rng_state ^= rng_state >> 27;
@@ -349,7 +349,7 @@ fn run_one(
                     // Algorithm R reservoir sampling: increment `seen` first so
                     // P(replace) = SAMPLE_CAP / seen, which goes to 0 as the stream
                     // grows (rather than 1, which would over-replace the earliest
-                    // samples — the bug in an earlier revision).
+                    // samples).
                     seen += 1;
                     if latencies.len() < SAMPLE_CAP {
                         latencies.push(dt);
@@ -577,9 +577,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Workdir layout:
-    //   /work/data/source/   — pre-populated DB, written once, mounted read-only
+    //   /work/data/source/   - pre-populated DB, written once, mounted read-only
     //                          for the per-config runs.
-    //   /work/data/scratch/  — per-config working copy.
+    //   /work/data/scratch/  - per-config working copy.
     //
     // LSMT_DIO_WORKDIR overrides the default tmp location so the populate step
     // can write to a host-mounted volume.

--- a/examples/run_bench.sh
+++ b/examples/run_bench.sh
@@ -27,6 +27,16 @@ export LSMT_DIO_WARMUP=${LSMT_DIO_WARMUP:-5}
 export LSMT_DIO_TARGET_SIZE=${LSMT_DIO_TARGET_SIZE:-4194304}
 export LSMT_DIO_WRITE_BPS=${LSMT_DIO_WRITE_BPS:-26214400}
 
+# Clean up the named volume and temp results dir on *any* exit (including a
+# failing docker/grep/python3 under `set -e`), so an aborted run doesn't leak
+# state. RESULTS_DIR is created later; the guard tolerates it being unset.
+RESULTS_DIR=""
+cleanup() {
+    docker volume rm "${VOL_NAME}" >/dev/null 2>&1 || true
+    [ -n "${RESULTS_DIR}" ] && rm -rf "${RESULTS_DIR}"
+}
+trap cleanup EXIT
+
 echo ">>> Phase 1: populate (no memory limit)"
 docker volume rm "${VOL_NAME}" >/dev/null 2>&1 || true
 docker volume create "${VOL_NAME}" >/dev/null
@@ -85,5 +95,4 @@ for r in data:
     done
 }
 
-docker volume rm "${VOL_NAME}" >/dev/null 2>&1 || true
-rm -rf "${RESULTS_DIR}"
+# Cleanup runs via the EXIT trap above.

--- a/examples/run_bench.sh
+++ b/examples/run_bench.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Two-phase benchmark runner.
+#
+# Phase 1: populate the source DB in a container with no memory limit (mirrors
+# the RocksDB PR's "Build the source DB once, unrestricted memory" step).
+#
+# Phase 2: for each config permutation, run the workload in a *fresh* container
+# with the memory cgroup. Each container exit drops its share of the kernel page
+# cache, so configs measured later don't inherit pollution from earlier ones.
+set -euo pipefail
+
+IMAGE=${IMAGE:-lsm-tree-bench:latest}
+VOL_NAME=${VOL_NAME:-lsm-tree-bench-data}
+# 1 GiB cgroup matches the RocksDB PR. The container's working memory (process
+# + memtables + block cache + scratch FS pages) sits comfortably under this
+# while still putting cache pressure on a multi-GiB DB.
+MEMORY=${MEMORY:-1g}
+
+# Workload knobs. Defaults are tuned for a 1 GiB cgroup with a 200 MiB DB and
+# 25 MB/s write throttle — high enough to drive continuous compaction without
+# running the cgroup out of headroom for the bench's working memory.
+export LSMT_DIO_TOTAL=${LSMT_DIO_TOTAL:-50000}
+export LSMT_DIO_NUM=${LSMT_DIO_NUM:-1000}
+export LSMT_DIO_VALUE_SIZE=${LSMT_DIO_VALUE_SIZE:-4096}
+export LSMT_DIO_DURATION=${LSMT_DIO_DURATION:-30}
+export LSMT_DIO_WARMUP=${LSMT_DIO_WARMUP:-5}
+export LSMT_DIO_TARGET_SIZE=${LSMT_DIO_TARGET_SIZE:-4194304}
+export LSMT_DIO_WRITE_BPS=${LSMT_DIO_WRITE_BPS:-26214400}
+
+echo ">>> Phase 1: populate (no memory limit)"
+docker volume rm "${VOL_NAME}" >/dev/null 2>&1 || true
+docker volume create "${VOL_NAME}" >/dev/null
+
+docker run --rm \
+  -v "${VOL_NAME}":/data \
+  -e LSMT_DIO_MODE=populate \
+  -e LSMT_DIO_WORKDIR=/data \
+  -e LSMT_DIO_TOTAL \
+  -e LSMT_DIO_VALUE_SIZE \
+  -e LSMT_DIO_TARGET_SIZE \
+  "${IMAGE}"
+
+echo
+echo ">>> Phase 2: run (memory limit ${MEMORY}, one container per config)"
+
+declare -a CONFIGS=(buffered writes_only reads_only both)
+RESULTS_DIR=$(mktemp -d)
+for cfg in "${CONFIGS[@]}"; do
+    echo
+    echo "----- $cfg -----"
+    docker run --rm \
+      --memory="${MEMORY}" \
+      --memory-swap="${MEMORY}" \
+      -v "${VOL_NAME}":/data \
+      -e LSMT_DIO_MODE=run \
+      -e LSMT_DIO_CONFIG="${cfg}" \
+      -e LSMT_DIO_WORKDIR=/data \
+      -e LSMT_DIO_TOTAL \
+      -e LSMT_DIO_NUM \
+      -e LSMT_DIO_VALUE_SIZE \
+      -e LSMT_DIO_DURATION \
+      -e LSMT_DIO_WARMUP \
+      -e LSMT_DIO_TARGET_SIZE \
+      -e LSMT_DIO_WRITE_BPS \
+      "${IMAGE}" 2>&1 | tee "${RESULTS_DIR}/${cfg}.log"
+done
+
+echo
+echo ">>> Aggregated results"
+{
+    printf '%-14s  %11s  %9s  %9s  %10s  %11s\n' \
+        "config" "throughput" "P50 (us)" "P99 (us)" "P99.9 (us)" "P99.99 (us)"
+    printf '%s\n' "------------------------------------------------------------------------------"
+    for cfg in "${CONFIGS[@]}"; do
+        grep '^JSON: ' "${RESULTS_DIR}/${cfg}.log" \
+            | sed 's/^JSON: //' \
+            | python3 -c '
+import json, sys
+data = json.loads(sys.stdin.read())
+for r in data:
+    print(f"{r[\"config\"]:<14}  {r[\"throughput\"]:>11.0f}  "
+          f"{r[\"p50_us\"]:>9.2f}  {r[\"p99_us\"]:>9.2f}  "
+          f"{r[\"p999_us\"]:>10.1f}  {r[\"p9999_us\"]:>11.1f}")
+'
+    done
+}
+
+docker volume rm "${VOL_NAME}" >/dev/null 2>&1 || true
+rm -rf "${RESULTS_DIR}"

--- a/examples/run_bench.sh
+++ b/examples/run_bench.sh
@@ -17,7 +17,7 @@ VOL_NAME=${VOL_NAME:-lsm-tree-bench-data}
 MEMORY=${MEMORY:-1g}
 
 # Workload knobs. Defaults are tuned for a 1 GiB cgroup with a 200 MiB DB and
-# 25 MB/s write throttle — high enough to drive continuous compaction without
+# 25 MB/s write throttle, high enough to drive continuous compaction without
 # running the cgroup out of headroom for the bench's working memory.
 export LSMT_DIO_TOTAL=${LSMT_DIO_TOTAL:-50000}
 export LSMT_DIO_NUM=${LSMT_DIO_NUM:-1000}

--- a/src/blob_tree/ingest.rs
+++ b/src/blob_tree/ingest.rs
@@ -43,11 +43,14 @@ impl<'a> BlobIngestion<'a> {
         let blob_file_size = kv.file_target_size;
 
         let table = TableIngestion::new(&tree.index)?;
+        // Blob-file writes during ingest honor the same direct-I/O knob as flush
+        // and compaction-output (they are equivalently write-once data).
         let blob = BlobFileWriter::new(
             tree.index.0.blob_file_id_counter.clone(),
             tree.index.config.path.join(BLOBS_FOLDER),
             tree.index.id,
             tree.index.config.descriptor_table.clone(),
+            tree.index.config.use_direct_io_for_flush_and_compaction,
         )?
         .use_target_size(blob_file_size)
         .use_compression(kv.compression);

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -384,6 +384,7 @@ impl AbstractTree for BlobTree {
             self.index.table_id_counter.clone(),
             64 * 1_024 * 1_024,
             0,
+            self.index.config.use_direct_io_for_flush_and_compaction,
         )?
         .use_data_block_restart_interval(data_block_restart_interval)
         .use_index_block_restart_interval(index_block_restart_interval)
@@ -424,6 +425,7 @@ impl AbstractTree for BlobTree {
             self.index.config.path.join(BLOBS_FOLDER),
             self.id(),
             self.index.config.descriptor_table.clone(),
+            self.index.config.use_direct_io_for_flush_and_compaction,
         )?
         .use_target_size(kv_opts.file_target_size)
         .use_compression(kv_opts.compression);

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -82,6 +82,15 @@ impl<W: std::io::Write> ChecksummedWriter<W> {
     pub fn inner_mut(&mut self) -> &mut W {
         &mut self.inner
     }
+
+    /// Consumes the wrapper and returns the inner writer plus the accumulated checksum.
+    ///
+    /// Used at finalization to take ownership of the underlying file for the platform
+    /// `set_len` + `sync_all` step required by direct-I/O writers.
+    pub fn into_inner(self) -> (W, Checksum) {
+        let checksum = Checksum::from_raw(self.hasher.digest128());
+        (self.inner, checksum)
+    }
 }
 
 impl<W: std::io::Write> std::io::Write for ChecksummedWriter<W> {
@@ -90,7 +99,114 @@ impl<W: std::io::Write> std::io::Write for ChecksummedWriter<W> {
     }
 
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.hasher.update(buf);
-        self.inner.write(buf)
+        // Hash only the bytes the inner writer accepted. Hashing `buf` first would
+        // double-count bytes on retries when `inner.write` returns `n < buf.len()`
+        // (which `AlignedFileWriter` deliberately does once its internal buffer
+        // fills): the default `Write::write_all` retries with `&buf[n..]`, and each
+        // retry would re-hash an overlapping prefix.
+        let n = self.inner.write(buf)?;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "n <= buf.len() per Write::write contract"
+        )]
+        self.hasher.update(&buf[..n]);
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use test_log::test;
+
+    // Mock writer that returns short writes on demand, exercising the same path
+    // `AlignedFileWriter` triggers when its internal aligned buffer fills.
+    struct ShortWriter {
+        accumulated: Vec<u8>,
+        chunk_size: usize,
+    }
+
+    impl Write for ShortWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let n = buf.len().min(self.chunk_size);
+            #[expect(clippy::indexing_slicing, reason = "n <= buf.len()")]
+            self.accumulated.extend_from_slice(&buf[..n]);
+            Ok(n)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn checksum_matches_actual_bytes_under_short_writes() -> std::io::Result<()> {
+        let payload: Vec<u8> = (0..10_000u32).map(|i| (i & 0xFF) as u8).collect();
+
+        // Reference: hash the payload directly.
+        let mut reference_hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        reference_hasher.update(&payload);
+        let reference = reference_hasher.digest128();
+
+        // Pipe through ChecksummedWriter -> ShortWriter (returns 64-byte chunks).
+        // `Write::write_all` will issue ~157 retries; the buggy implementation
+        // would re-hash later bytes on each retry.
+        let short_writer = ShortWriter {
+            accumulated: Vec::new(),
+            chunk_size: 64,
+        };
+        let mut cw = ChecksummedWriter::new(short_writer);
+        cw.write_all(&payload)?;
+
+        let (inner, observed) = cw.into_inner();
+        assert_eq!(inner.accumulated, payload);
+        assert_eq!(observed.into_u128(), reference);
+        Ok(())
+    }
+
+    #[test]
+    fn checksum_check_matches_and_mismatches() {
+        let a = Checksum::from_raw(0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF_u128);
+        let b = Checksum::from_raw(0x1234_u128);
+        // Equal pair: ok.
+        a.check(a).unwrap();
+        // Different pair: returns ChecksumMismatch with both sides preserved.
+        let err = a.check(b).unwrap_err();
+        match err {
+            crate::Error::ChecksumMismatch { expected, got } => {
+                assert_eq!(expected, b);
+                assert_eq!(got, a);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn checksum_display_is_debug() {
+        let c = Checksum::from_raw(42);
+        assert_eq!(format!("{c}"), format!("{c:?}"));
+    }
+
+    #[test]
+    fn checksum_writer_inner_mut_returns_underlying() -> std::io::Result<()> {
+        let mut cw = ChecksummedWriter::new(Vec::<u8>::new());
+        cw.write_all(b"abc")?;
+        // Drive the inner writer directly via inner_mut; those bytes bypass the
+        // hasher.
+        cw.inner_mut().extend_from_slice(b"xyz");
+        let (inner, ck) = cw.into_inner();
+        assert_eq!(inner, b"abcxyz");
+
+        // The recorded checksum covers only "abc", not "abcxyz".
+        let mut h = xxhash_rust::xxh3::Xxh3Default::new();
+        h.update(b"abc");
+        assert_eq!(ck.into_u128(), h.digest128());
+        Ok(())
+    }
+
+    #[test]
+    fn checksum_type_u8_round() {
+        let u: u8 = ChecksumType::Xxh3.into();
+        assert_eq!(u, 0);
     }
 }

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -85,8 +85,8 @@ impl<W: std::io::Write> ChecksummedWriter<W> {
 
     /// Consumes the wrapper and returns the inner writer plus the accumulated checksum.
     ///
-    /// Used at finalization to take ownership of the underlying file for the platform
-    /// `set_len` + `sync_all` step required by direct-I/O writers.
+    /// Called at finalization to take back the inner writer so it can be drained
+    /// and `sync_all`'d.
     pub fn into_inner(self) -> (W, Checksum) {
         let checksum = Checksum::from_raw(self.hasher.digest128());
         (self.inner, checksum)

--- a/src/compaction/filter.rs
+++ b/src/compaction/filter.rs
@@ -229,6 +229,10 @@ impl<'a, 'b: 'a> StreamFilterAdapter<'a, 'b> {
                 self.shared.blobs_folder,
                 self.shared.opts.tree_id,
                 self.shared.opts.config.descriptor_table.clone(),
+                self.shared
+                    .opts
+                    .config
+                    .use_direct_io_for_flush_and_compaction,
             )?
             .use_target_size(blob_opts.file_target_size)
             .use_compression(blob_opts.compression);

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -77,6 +77,7 @@ pub(super) fn prepare_table_writer(
         opts.table_id_generator.clone(),
         payload.target_size,
         payload.dest_level,
+        opts.config.use_direct_io_for_flush_and_compaction,
     )?;
 
     if index_partitioning {

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -150,6 +150,7 @@ fn create_compaction_stream<'a>(
     version: &Version,
     to_compact: &[TableId],
     eviction_seqno: SeqNo,
+    use_direct_io: bool,
 ) -> crate::Result<Option<CompactionStream<'a, Merger<CompactionReader<'a>>>>> {
     let mut readers: Vec<CompactionReader<'_>> = vec![];
     let mut found = 0;
@@ -163,13 +164,14 @@ fn create_compaction_stream<'a>(
             readers.push(Box::new(RunScanner::culled(
                 run.clone(),
                 (Some(lo), Some(hi)),
+                use_direct_io,
             )?));
 
             found += hi - lo + 1;
         } else {
             for table in run.iter().filter(|x| to_compact.contains(&x.metadata.id)) {
                 found += 1;
-                readers.push(Box::new(table.scan()?));
+                readers.push(Box::new(table.scan(use_direct_io)?));
             }
         }
     }
@@ -370,6 +372,7 @@ fn merge_tables(
         &current_super_version.version,
         &payload.table_ids.iter().copied().collect::<Vec<_>>(),
         opts.mvcc_gc_watermark,
+        opts.config.use_direct_io_for_compaction_reads,
     )?
     else {
         log::warn!(
@@ -444,7 +447,13 @@ fn merge_tables(
                 let scanner = BlobFileMergeScanner::new(
                     blob_files_to_rewrite
                         .iter()
-                        .map(|bf| BlobFileScanner::new(&bf.0.path, bf.id()))
+                        .map(|bf| {
+                            BlobFileScanner::new(
+                                &bf.0.path,
+                                bf.id(),
+                                opts.config.use_direct_io_for_compaction_reads,
+                            )
+                        })
                         .collect::<crate::Result<Vec<_>>>()?,
                 );
 
@@ -453,6 +462,7 @@ fn merge_tables(
                     &blobs_folder,
                     opts.tree_id,
                     opts.config.descriptor_table.clone(),
+                    opts.config.use_direct_io_for_flush_and_compaction,
                 )?
                 .use_target_size(blob_opts.file_target_size)
                 .use_passthrough_compression(blob_opts.compression);
@@ -673,7 +683,7 @@ mod tests {
         tree.insert("a", "a", 0);
         tree.flush_active_memtable(0)?;
 
-        assert!(create_compaction_stream(&tree.current_version(), &[666], 0)?.is_none());
+        assert!(create_compaction_stream(&tree.current_version(), &[666], 0, false)?.is_none());
 
         Ok(())
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -232,6 +232,28 @@ pub struct Config {
     #[doc(hidden)]
     pub kv_separation_opts: Option<KvSeparationOptions>,
 
+    /// If `true`, compaction-input SST and blob files are opened with platform-native
+    /// direct I/O (`O_DIRECT` on Linux, `F_NOCACHE` on macOS), bypassing the OS
+    /// page cache.
+    ///
+    /// Silent no-op on other platforms (including Windows). On Linux, if the
+    /// filesystem rejects `O_DIRECT` at runtime (e.g. tmpfs / overlayfs / some
+    /// FUSE filesystems), opens transparently fall back to buffered I/O and log
+    /// a single `warn`.
+    ///
+    /// Defaults to `false`.
+    pub(crate) use_direct_io_for_compaction_reads: bool,
+
+    /// If `true`, the SST and blob files produced by flush, ingest, and compaction-output
+    /// are opened with direct I/O.
+    ///
+    /// Silent no-op on platforms without a direct-I/O mechanism (including
+    /// Windows). On Linux, if the filesystem rejects `O_DIRECT` at runtime,
+    /// opens transparently fall back to buffered I/O and log a single `warn`.
+    ///
+    /// Defaults to `false`.
+    pub(crate) use_direct_io_for_flush_and_compaction: bool,
+
     /// The global sequence number generator
     ///
     /// Should be shared between multple trees of a database
@@ -294,6 +316,9 @@ impl Default for Config {
             expect_point_read_hits: false,
 
             kv_separation_opts: None,
+
+            use_direct_io_for_compaction_reads: false,
+            use_direct_io_for_flush_and_compaction: false,
         }
     }
 }
@@ -457,6 +482,44 @@ impl Config {
     #[must_use]
     pub fn with_kv_separation(mut self, opts: Option<KvSeparationOptions>) -> Self {
         self.kv_separation_opts = opts;
+        self
+    }
+
+    /// Enables direct I/O for compaction-input reads.
+    ///
+    /// When `true`, the file handles opened by the compaction worker to read
+    /// existing SST and blob files use `O_DIRECT` (Linux) or `F_NOCACHE` (macOS).
+    /// This avoids polluting the OS page cache with sequential, read-once
+    /// compaction data, protecting user-read tail latency on cache-pressured
+    /// workloads.
+    ///
+    /// Silent no-op on other platforms (including Windows). On Linux where the
+    /// filesystem rejects `O_DIRECT` at runtime, transparently falls back to
+    /// buffered I/O.
+    ///
+    /// For best results, pair with [`Config::use_direct_io_for_flush_and_compaction`].
+    ///
+    /// Defaults to `false`.
+    #[must_use]
+    pub fn use_direct_io_for_compaction_reads(mut self, b: bool) -> Self {
+        self.use_direct_io_for_compaction_reads = b;
+        self
+    }
+
+    /// Enables direct I/O for flush, ingest, and compaction-output writes.
+    ///
+    /// When `true`, newly created SST and blob files (from flush, bulk ingest, and
+    /// compaction) are opened with `O_DIRECT` (Linux) or `F_NOCACHE` (macOS).
+    /// This avoids polluting the OS page cache with write-once data.
+    ///
+    /// Silent no-op on other platforms (including Windows). On Linux where the
+    /// filesystem rejects `O_DIRECT` at runtime, transparently falls back to
+    /// buffered I/O.
+    ///
+    /// Defaults to `false`.
+    #[must_use]
+    pub fn use_direct_io_for_flush_and_compaction(mut self, b: bool) -> Self {
+        self.use_direct_io_for_flush_and_compaction = b;
         self
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -237,10 +237,9 @@ pub struct Config {
     /// page cache.
     ///
     /// Silent no-op on other platforms (including Windows). On Linux, if the
-    /// filesystem rejects `O_DIRECT` (most filesystems that lack support reject it
-    /// at open — tmpfs / overlayfs / some FUSE — but a few reject it only on the
-    /// actual reads/writes), the I/O transparently falls back to buffered and logs
-    /// a single `warn`.
+    /// filesystem rejects `O_DIRECT` (most reject it at open: tmpfs, overlayfs,
+    /// some FUSE; a few only on the reads/writes), the I/O falls back to buffered
+    /// and logs a single `warn`.
     ///
     /// Defaults to `false`.
     pub(crate) use_direct_io_for_compaction_reads: bool,
@@ -249,9 +248,9 @@ pub struct Config {
     /// are opened with direct I/O.
     ///
     /// Silent no-op on platforms without a direct-I/O mechanism (including
-    /// Windows). On Linux, if the filesystem rejects `O_DIRECT` (at open, or — for
-    /// the few filesystems that accept the open but reject the writes — at write
-    /// time), the I/O transparently falls back to buffered and logs a single `warn`.
+    /// Windows). On Linux, if the filesystem rejects `O_DIRECT` (at open, or at
+    /// write time for the few filesystems that accept the open but reject the
+    /// writes), the I/O falls back to buffered and logs a single `warn`.
     ///
     /// Defaults to `false`.
     pub(crate) use_direct_io_for_flush_and_compaction: bool,
@@ -495,9 +494,8 @@ impl Config {
     /// compaction data, protecting user-read tail latency on cache-pressured
     /// workloads.
     ///
-    /// Silent no-op on other platforms (including Windows). On Linux where the
-    /// filesystem rejects `O_DIRECT` at runtime, transparently falls back to
-    /// buffered I/O.
+    /// Silent no-op on other platforms (including Windows). On Linux, if the
+    /// filesystem rejects `O_DIRECT`, falls back to buffered I/O.
     ///
     /// For best results, pair with [`Config::use_direct_io_for_flush_and_compaction`].
     ///
@@ -514,9 +512,8 @@ impl Config {
     /// compaction) are opened with `O_DIRECT` (Linux) or `F_NOCACHE` (macOS).
     /// This avoids polluting the OS page cache with write-once data.
     ///
-    /// Silent no-op on other platforms (including Windows). On Linux where the
-    /// filesystem rejects `O_DIRECT` at runtime, transparently falls back to
-    /// buffered I/O.
+    /// Silent no-op on other platforms (including Windows). On Linux, if the
+    /// filesystem rejects `O_DIRECT`, falls back to buffered I/O.
     ///
     /// Defaults to `false`.
     #[must_use]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -237,8 +237,9 @@ pub struct Config {
     /// page cache.
     ///
     /// Silent no-op on other platforms (including Windows). On Linux, if the
-    /// filesystem rejects `O_DIRECT` at runtime (e.g. tmpfs / overlayfs / some
-    /// FUSE filesystems), opens transparently fall back to buffered I/O and log
+    /// filesystem rejects `O_DIRECT` (most filesystems that lack support reject it
+    /// at open — tmpfs / overlayfs / some FUSE — but a few reject it only on the
+    /// actual reads/writes), the I/O transparently falls back to buffered and logs
     /// a single `warn`.
     ///
     /// Defaults to `false`.
@@ -248,8 +249,9 @@ pub struct Config {
     /// are opened with direct I/O.
     ///
     /// Silent no-op on platforms without a direct-I/O mechanism (including
-    /// Windows). On Linux, if the filesystem rejects `O_DIRECT` at runtime,
-    /// opens transparently fall back to buffered I/O and log a single `warn`.
+    /// Windows). On Linux, if the filesystem rejects `O_DIRECT` (at open, or — for
+    /// the few filesystems that accept the open but reject the writes — at write
+    /// time), the I/O transparently falls back to buffered and logs a single `warn`.
     ///
     /// Defaults to `false`.
     pub(crate) use_direct_io_for_flush_and_compaction: bool,

--- a/src/direct_io/aligned_buffer.rs
+++ b/src/direct_io/aligned_buffer.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+use std::alloc::{alloc_zeroed, dealloc, Layout};
+
+/// Heap-allocated buffer whose start address is aligned to a runtime-determined boundary.
+///
+/// Required for `O_DIRECT` on Linux, which rejects `read`/`write` calls whose user
+/// buffer pointer is not aligned to the device's logical block size (typically
+/// 512 B or 4 KiB).
+pub struct AlignedBuffer {
+    ptr: *mut u8,
+    layout: Layout,
+}
+
+// SAFETY: AlignedBuffer owns a unique allocation and exposes &mut [u8] only through &mut self,
+// so it has the same threading guarantees as Box<[u8]>.
+#[expect(unsafe_code, reason = "raw alloc requires unsafe")]
+unsafe impl Send for AlignedBuffer {}
+
+// SAFETY: see Send impl.
+#[expect(unsafe_code, reason = "raw alloc requires unsafe")]
+unsafe impl Sync for AlignedBuffer {}
+
+impl AlignedBuffer {
+    /// Allocates a zeroed buffer of `capacity` bytes, with start address aligned to `alignment`.
+    ///
+    /// `capacity` must be a multiple of `alignment`; otherwise the OS may reject the I/O
+    /// even though the start is aligned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the allocation fails or the arguments do not satisfy `Layout::from_size_align`.
+    #[must_use]
+    pub fn new(capacity: usize, alignment: usize) -> Self {
+        assert!(capacity > 0, "AlignedBuffer capacity must be > 0");
+        assert!(
+            alignment.is_power_of_two(),
+            "AlignedBuffer alignment ({alignment}) must be a power of two",
+        );
+        assert!(
+            capacity.is_multiple_of(alignment),
+            "AlignedBuffer capacity ({capacity}) must be a multiple of alignment ({alignment})",
+        );
+
+        // Layout::from_size_align rejects non-power-of-two alignments and oversize
+        // (rounded-up size that overflows isize). Both are excluded by the asserts
+        // above plus the BUFFER_BLOCKS bound on capacity.
+        #[expect(clippy::expect_used, reason = "alignment and capacity validated above")]
+        let layout = Layout::from_size_align(capacity, alignment)
+            .expect("alignment is a power of two and capacity fits");
+
+        // SAFETY: layout has non-zero size (asserted above); alloc_zeroed returns an
+        // aligned pointer or null. We check for null and abort if alloc failed.
+        #[expect(unsafe_code, reason = "raw alloc requires unsafe")]
+        let ptr = unsafe { alloc_zeroed(layout) };
+
+        if ptr.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+
+        Self { ptr, layout }
+    }
+
+    /// Returns the buffer as an immutable slice covering its entire allocated capacity.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: ptr was produced by alloc_zeroed with size=layout.size(); buffer is initialized.
+        #[expect(unsafe_code, reason = "raw pointer dereference")]
+        unsafe {
+            std::slice::from_raw_parts(self.ptr, self.layout.size())
+        }
+    }
+
+    /// Returns the buffer as a mutable slice covering its entire allocated capacity.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: see as_slice; &mut self enforces unique access.
+        #[expect(unsafe_code, reason = "raw pointer dereference")]
+        unsafe {
+            std::slice::from_raw_parts_mut(self.ptr, self.layout.size())
+        }
+    }
+
+    /// Returns the buffer capacity in bytes.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.layout.size()
+    }
+
+    /// Returns the alignment of the buffer's start pointer.
+    #[cfg(test)]
+    #[must_use]
+    pub fn alignment(&self) -> usize {
+        self.layout.align()
+    }
+}
+
+impl Drop for AlignedBuffer {
+    fn drop(&mut self) {
+        // SAFETY: ptr and layout match the original alloc_zeroed call.
+        #[expect(unsafe_code, reason = "raw dealloc requires unsafe")]
+        unsafe {
+            dealloc(self.ptr, self.layout);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    #[test]
+    fn aligned_buffer_basic() {
+        let mut buf = AlignedBuffer::new(4_096, 4_096);
+        assert_eq!(buf.capacity(), 4_096);
+        assert_eq!(buf.alignment(), 4_096);
+
+        assert!((buf.as_slice().as_ptr() as usize).is_multiple_of(4_096));
+
+        // Round-trip data
+        for (i, b) in buf.as_mut_slice().iter_mut().enumerate() {
+            #[expect(clippy::cast_possible_truncation, reason = "test loop is small")]
+            {
+                *b = (i & 0xFF) as u8;
+            }
+        }
+        for (i, &b) in buf.as_slice().iter().enumerate() {
+            #[expect(clippy::cast_possible_truncation, reason = "test loop is small")]
+            {
+                assert_eq!(b, (i & 0xFF) as u8);
+            }
+        }
+    }
+
+    #[test]
+    fn aligned_buffer_pointer_is_aligned_to_alignment() {
+        for align_log2 in 9..=14 {
+            let align = 1usize << align_log2;
+            let buf = AlignedBuffer::new(align * 2, align);
+            assert_eq!(
+                (buf.as_slice().as_ptr() as usize) % align,
+                0,
+                "buffer pointer not aligned to {align}",
+            );
+        }
+    }
+
+    #[test]
+    fn aligned_buffer_starts_zeroed() {
+        let buf = AlignedBuffer::new(4_096, 512);
+        assert!(buf.as_slice().iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a multiple of alignment")]
+    fn aligned_buffer_capacity_not_multiple_of_alignment() {
+        let _ = AlignedBuffer::new(3_000, 4_096);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be > 0")]
+    fn aligned_buffer_zero_capacity() {
+        let _ = AlignedBuffer::new(0, 4_096);
+    }
+}

--- a/src/direct_io/aligned_reader.rs
+++ b/src/direct_io/aligned_reader.rs
@@ -94,7 +94,7 @@ impl AlignedFileReader {
                     // Filesystem accepted O_DIRECT at open but rejects the read
                     // (some FUSE/overlay setups, or a device whose logical block
                     // size exceeds our alignment). Drop O_DIRECT and retry
-                    // buffered from the same offset — the rejected read advanced
+                    // buffered from the same offset; the rejected read advanced
                     // nothing. Mirrors the writer's runtime fallback.
                     log_runtime_read_fallback_once(&e);
                     disable_direct_io_for_remainder(&self.file)?;

--- a/src/direct_io/aligned_reader.rs
+++ b/src/direct_io/aligned_reader.rs
@@ -1,0 +1,359 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+use super::{aligned_buffer::AlignedBuffer, BUFFER_BLOCKS};
+use std::{fs::File, io};
+
+/// Buffered reader that issues aligned reads to a direct-I/O-opened file.
+///
+/// Each refill reads `BUFFER_BLOCKS * alignment` bytes (or less if the file is shorter)
+/// from the current file offset. Callers may then consume bytes at any granularity;
+/// the reader hands them out from the aligned buffer.
+///
+/// `O_DIRECT` reads beyond end-of-file return a short read (fewer bytes than
+/// requested). Short reads can also happen before EOF, so the reader tracks the
+/// known file length and only latches `eof` once the logical file position reaches
+/// that length.
+pub struct AlignedFileReader {
+    file: File,
+    buffer: AlignedBuffer,
+    alignment: usize,
+    /// Immutable file length observed when the compaction input was opened.
+    file_len: u64,
+    /// Kernel file offset after the most recent refill.
+    file_pos: u64,
+    /// Number of valid bytes currently in the buffer (between 0 and `buffer.capacity()`).
+    valid_len: usize,
+    /// Next byte position to return to the caller, within `buffer[..valid_len]`.
+    cursor: usize,
+    /// Set after the reader reaches `file_len` or observes `read() == 0`.
+    eof: bool,
+}
+
+impl AlignedFileReader {
+    /// Wraps an already-opened file (assumed to have direct-I/O enabled).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file length cannot be read.
+    pub fn new(file: File, alignment: usize) -> io::Result<Self> {
+        let capacity = alignment.saturating_mul(BUFFER_BLOCKS).max(alignment);
+        let file_len = file.metadata()?.len();
+        Ok(Self {
+            file,
+            buffer: AlignedBuffer::new(capacity, alignment),
+            alignment,
+            file_len,
+            file_pos: 0,
+            valid_len: 0,
+            cursor: 0,
+            eof: false,
+        })
+    }
+
+    fn refill(&mut self) -> io::Result<()> {
+        use io::Read;
+
+        self.cursor = 0;
+        self.valid_len = 0;
+
+        if self.eof {
+            return Ok(());
+        }
+
+        if self.file_pos >= self.file_len {
+            self.eof = true;
+            return Ok(());
+        }
+
+        let read_len = self.refill_read_len();
+        let read_buf = self
+            .buffer
+            .as_mut_slice()
+            .get_mut(..read_len)
+            .ok_or_else(|| {
+                io::Error::other("direct-I/O refill length exceeded aligned buffer capacity")
+            })?;
+        let n = loop {
+            match self.file.read(read_buf) {
+                Ok(n) => break n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        };
+
+        if n == 0 {
+            self.eof = true;
+            if self.file_pos < self.file_len {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "direct-I/O read returned EOF at offset {} before known file length {}",
+                        self.file_pos, self.file_len,
+                    ),
+                ));
+            }
+            return Ok(());
+        }
+
+        self.valid_len = n;
+
+        let n_u64 = u64::try_from(n).map_err(|_| {
+            io::Error::other("direct-I/O read length does not fit into a u64 file offset")
+        })?;
+        self.file_pos = self.file_pos.checked_add(n_u64).ok_or_else(|| {
+            io::Error::other("direct-I/O read advanced past the maximum u64 file offset")
+        })?;
+
+        if self.file_pos >= self.file_len {
+            self.eof = true;
+        } else if !n.is_multiple_of(self.alignment) {
+            disable_direct_io_for_remainder(&self.file)?;
+        }
+        Ok(())
+    }
+
+    fn refill_read_len(&self) -> usize {
+        forced_max_read_len(self.buffer.capacity(), self.alignment)
+            .unwrap_or_else(|| self.buffer.capacity())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn disable_direct_io_for_remainder(file: &File) -> io::Result<()> {
+    super::linux::disable_direct_io(file)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "matches the Linux helper signature so refill can use one call site"
+)]
+fn disable_direct_io_for_remainder(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+const TEST_MAX_READ_BYTES_ENV: &str = "LSM_TREE_TEST_DIRECT_IO_MAX_READ_BYTES";
+
+#[cfg(debug_assertions)]
+fn forced_max_read_len(capacity: usize, alignment: usize) -> Option<usize> {
+    let limit = std::env::var(TEST_MAX_READ_BYTES_ENV)
+        .ok()?
+        .parse::<usize>()
+        .ok()?
+        .min(capacity);
+    let aligned = (limit / alignment) * alignment;
+    if aligned == 0 {
+        None
+    } else {
+        Some(aligned)
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn forced_max_read_len(_capacity: usize, _alignment: usize) -> Option<usize> {
+    None
+}
+
+impl io::Read for AlignedFileReader {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        if dst.is_empty() {
+            return Ok(0);
+        }
+
+        if self.cursor == self.valid_len {
+            self.refill()?;
+            if self.valid_len == 0 {
+                return Ok(0);
+            }
+        }
+
+        let available = self.valid_len - self.cursor;
+        let n = dst.len().min(available);
+        // Bounded by the min above; both slices are `n` bytes and indices are valid.
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "n is bounded by both dst.len() and (valid_len - cursor), so all indices are valid"
+        )]
+        {
+            dst[..n].copy_from_slice(&self.buffer.as_slice()[self.cursor..self.cursor + n]);
+        }
+        self.cursor += n;
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use test_log::test;
+
+    fn alignment_for_test() -> usize {
+        512
+    }
+
+    fn write_data(path: &std::path::Path, data: &[u8]) -> io::Result<()> {
+        let mut f = std::fs::File::create(path)?;
+        f.write_all(data)?;
+        f.sync_all()?;
+        Ok(())
+    }
+
+    #[cfg(debug_assertions)]
+    struct ForcedMaxReadGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    #[cfg(debug_assertions)]
+    impl ForcedMaxReadGuard {
+        fn set(max_read_bytes: usize) -> Self {
+            let previous = std::env::var_os(TEST_MAX_READ_BYTES_ENV);
+            std::env::set_var(TEST_MAX_READ_BYTES_ENV, max_read_bytes.to_string());
+            Self { previous }
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    impl Drop for ForcedMaxReadGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(TEST_MAX_READ_BYTES_ENV, previous);
+            } else {
+                std::env::remove_var(TEST_MAX_READ_BYTES_ENV);
+            }
+        }
+    }
+
+    #[test]
+    fn aligned_reader_roundtrip_exact_alignment() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("exact");
+        let align = alignment_for_test();
+        let data: Vec<u8> = (0..(align * 4)).map(|i| (i & 0xFF) as u8).collect();
+        write_data(&path, &data)?;
+
+        let file = std::fs::File::open(&path)?;
+        let mut reader = AlignedFileReader::new(file, align)?;
+
+        let mut out = vec![];
+        reader.read_to_end(&mut out)?;
+        assert_eq!(data, out);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_reader_roundtrip_unaligned_length() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("unaligned");
+        let align = alignment_for_test();
+        let data: Vec<u8> = (0..(align * 2 + 173)).map(|i| (i & 0xFF) as u8).collect();
+        write_data(&path, &data)?;
+
+        let file = std::fs::File::open(&path)?;
+        let mut reader = AlignedFileReader::new(file, align)?;
+
+        let mut out = vec![];
+        reader.read_to_end(&mut out)?;
+        assert_eq!(data, out);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_reader_many_small_reads() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("small");
+        let align = alignment_for_test();
+        let total = align * 3 + 5;
+        let data: Vec<u8> = (0..total).map(|i| (i & 0xFF) as u8).collect();
+        write_data(&path, &data)?;
+
+        let file = std::fs::File::open(&path)?;
+        let mut reader = AlignedFileReader::new(file, align)?;
+
+        for (i, expected) in data.iter().enumerate() {
+            let mut byte = [0u8; 1];
+            let n = reader.read(&mut byte)?;
+            assert_eq!(n, 1, "short read at offset {i}");
+            assert_eq!(byte[0], *expected, "mismatch at offset {i}");
+        }
+        let mut after_end = [0u8; 1];
+        assert_eq!(reader.read(&mut after_end)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_reader_empty_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("empty");
+        let align = alignment_for_test();
+        write_data(&path, &[])?;
+
+        let file = std::fs::File::open(&path)?;
+        let mut reader = AlignedFileReader::new(file, align)?;
+
+        let mut buf = vec![];
+        reader.read_to_end(&mut buf)?;
+        assert!(buf.is_empty());
+        Ok(())
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn aligned_reader_continues_after_aligned_short_read_before_eof() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("short-before-eof");
+        let align = alignment_for_test();
+        let total = align * (BUFFER_BLOCKS + 3) + 17;
+        let data: Vec<u8> = (0..total).map(|i| (i & 0xFF) as u8).collect();
+        write_data(&path, &data)?;
+
+        let _guard = ForcedMaxReadGuard::set(align);
+        let file = std::fs::File::open(&path)?;
+        let mut reader = AlignedFileReader::new(file, align)?;
+
+        let mut out = vec![0; align];
+        reader.read_exact(&mut out)?;
+        assert!(
+            !reader.eof,
+            "short aligned read before EOF must not latch EOF"
+        );
+        assert_eq!(
+            reader.file_pos,
+            u64::try_from(align).map_err(|_| io::Error::other("alignment overflows u64"))?,
+        );
+
+        reader.read_to_end(&mut out)?;
+        assert_eq!(out, data);
+        assert!(reader.eof);
+        Ok(())
+    }
+
+    /// A short read at the known file length is EOF, even when the file's tail is
+    /// not alignment-sized.
+    #[test]
+    fn aligned_reader_latches_eof_on_short_read_at_known_file_end() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("short");
+        let align = alignment_for_test();
+        // File size is *exactly less* than one buffer capacity worth of data,
+        // forcing the first refill into a short read.
+        let total = align * 2 + 13; // 1037 bytes, well below 512*16 = 8192 capacity.
+        let data: Vec<u8> = (0..total).map(|i| (i & 0xFF) as u8).collect();
+        write_data(&path, &data)?;
+
+        let file = std::fs::File::open(&path)?;
+        let mut reader = AlignedFileReader::new(file, align)?;
+
+        let mut out = vec![];
+        reader.read_to_end(&mut out)?;
+        assert_eq!(out, data);
+        assert!(
+            reader.eof,
+            "reader should have latched EOF after the short read"
+        );
+        Ok(())
+    }
+}

--- a/src/direct_io/aligned_reader.rs
+++ b/src/direct_io/aligned_reader.rs
@@ -36,8 +36,14 @@ impl AlignedFileReader {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file length cannot be read.
+    /// Returns an error if `alignment` is zero or the file length cannot be read.
     pub fn new(file: File, alignment: usize) -> io::Result<Self> {
+        if alignment == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "direct-I/O alignment must be non-zero",
+            ));
+        }
         let capacity = alignment.saturating_mul(BUFFER_BLOCKS).max(alignment);
         let file_len = file.metadata()?.len();
         Ok(Self {

--- a/src/direct_io/aligned_reader.rs
+++ b/src/direct_io/aligned_reader.rs
@@ -81,10 +81,25 @@ impl AlignedFileReader {
             .ok_or_else(|| {
                 io::Error::other("direct-I/O refill length exceeded aligned buffer capacity")
             })?;
+        // At most one runtime buffered-fallback attempt: a second rejection after
+        // O_DIRECT is already cleared is a genuine error (and avoids any loop).
+        let mut tried_buffered_fallback = false;
         let n = loop {
             match self.file.read(read_buf) {
                 Ok(n) => break n,
                 Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e)
+                    if !tried_buffered_fallback && super::is_runtime_direct_io_unsupported(&e) =>
+                {
+                    // Filesystem accepted O_DIRECT at open but rejects the read
+                    // (some FUSE/overlay setups, or a device whose logical block
+                    // size exceeds our alignment). Drop O_DIRECT and retry
+                    // buffered from the same offset — the rejected read advanced
+                    // nothing. Mirrors the writer's runtime fallback.
+                    log_runtime_read_fallback_once(&e);
+                    disable_direct_io_for_remainder(&self.file)?;
+                    tried_buffered_fallback = true;
+                }
                 Err(e) => return Err(e),
             }
         };
@@ -138,6 +153,19 @@ fn disable_direct_io_for_remainder(file: &File) -> io::Result<()> {
 )]
 fn disable_direct_io_for_remainder(_file: &File) -> io::Result<()> {
     Ok(())
+}
+
+/// Warns a single time per process when a read falls back from direct to
+/// buffered I/O at runtime, so a misconfigured filesystem doesn't flood logs.
+fn log_runtime_read_fallback_once(e: &io::Error) {
+    use std::sync::OnceLock;
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        log::warn!(
+            "direct I/O read rejected at runtime (first observed: {e}); \
+             disabling O_DIRECT and continuing with buffered I/O for affected files.",
+        );
+    });
 }
 
 #[cfg(debug_assertions)]

--- a/src/direct_io/aligned_writer.rs
+++ b/src/direct_io/aligned_writer.rs
@@ -101,8 +101,13 @@ impl AlignedFileWriter {
         self.bytes_written
     }
 
-    /// Drains the trailing partial block (zero-padded to alignment), truncates the
-    /// file to the real byte count, and returns the inner `File`.
+    /// Drains the trailing partial block and returns the inner `File`.
+    ///
+    /// Any complete aligned chunks still buffered are written via the direct
+    /// handle; the final sub-alignment tail (if any) is written through a
+    /// separate buffered (non-`O_DIRECT`) handle so the file ends at exactly the
+    /// real byte count — no zero padding is ever persisted and no `set_len` is
+    /// needed.
     pub fn finalize(mut self) -> io::Result<File> {
         self.finalize_in_place()?;
         #[expect(
@@ -322,15 +327,17 @@ impl AlignedFileWriter {
 
 impl Drop for AlignedFileWriter {
     fn drop(&mut self) {
-        // If the caller didn't finalize/cancel and we're not poisoned, try to flush
-        // the tail and truncate. A failure here means the file may be left with up
-        // to one alignment unit of trailing zeros; log loudly because data integrity
-        // is at stake and the caller has lost the ability to react.
+        // If the caller didn't finalize/cancel and we're not poisoned, try to drain
+        // the tail. A failure here means the file may be left missing up to one
+        // alignment unit of trailing bytes (the unwritten sub-alignment tail); log
+        // loudly because data integrity is at stake and the caller has lost the
+        // ability to react. Note: Drop-time finalization is best-effort and does
+        // not fsync — production paths must call `finalize()` explicitly.
         if !self.finalized && !self.poisoned {
             if let Err(e) = self.finalize_in_place() {
                 log::error!(
                     "AlignedFileWriter dropped without explicit finalize and finalize_in_place failed: {e:?}; \
-                     file may have trailing zero padding",
+                     file may be missing up to one alignment unit of trailing bytes",
                 );
             }
         }

--- a/src/direct_io/aligned_writer.rs
+++ b/src/direct_io/aligned_writer.rs
@@ -1,0 +1,616 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+use super::{aligned_buffer::AlignedBuffer, BUFFER_BLOCKS};
+use std::{
+    fs::File,
+    io::{self, Write},
+    path::PathBuf,
+};
+
+/// Buffered writer that emits aligned, page-sized chunks to the underlying file.
+///
+/// `O_DIRECT` requires the buffer pointer, file offset, and length to all be
+/// multiples of the device's logical block size. This writer accumulates incoming
+/// bytes into an aligned heap buffer and only emits full, aligned chunks until
+/// `finalize` is called.
+///
+/// `finalize` writes the (possibly partial) trailing block via a separate buffered
+/// handle (opened without `O_DIRECT`). The alternative — writing a zero-padded
+/// block + `ftruncate` — leaks a short window where the file is larger than its
+/// logical content.
+///
+/// ## Error semantics
+///
+/// If any `Write::write` or `Write::flush` call returns an error, the writer enters
+/// a *poisoned* state: all subsequent write/flush/finalize calls return an error
+/// without touching the file. The on-disk file is left containing exactly the bytes
+/// from the last successful aligned spill — never extended beyond what made it to
+/// disk. Drop in the poisoned state is a no-op.
+pub struct AlignedFileWriter {
+    /// `Option` so `finalize` / `cancel` can take ownership of the file out of the
+    /// struct even though `AlignedFileWriter` implements `Drop`. `None` only between
+    /// the `take` and the function returning.
+    file: Option<File>,
+    /// Path of the file backing this writer. Needed by `finalize_in_place` to reopen
+    /// a buffered handle for the trailing partial-block write.
+    path: PathBuf,
+    buffer: AlignedBuffer,
+    /// Bytes currently buffered (between 0 and `buffer.capacity()`).
+    buffer_pos: usize,
+    /// Total real bytes written and accepted (never includes bytes from a failed
+    /// spill — see `Self::write`).
+    bytes_written: u64,
+    /// File size at the last successful write completion. On any `write_all`
+    /// failure we best-effort `set_len(bytes_on_disk)` so the on-disk file does
+    /// not exceed the last successful boundary (the documented error contract).
+    bytes_on_disk: u64,
+    alignment: usize,
+    /// Set to `true` after `finalize`/`cancel` runs so a double-finalize is a no-op.
+    finalized: bool,
+    /// Set to `true` after any I/O failure. Subsequent ops fail without touching the file.
+    poisoned: bool,
+}
+
+impl AlignedFileWriter {
+    /// Wraps an already-opened file (assumed to have direct-I/O enabled).
+    /// `path` is retained so `finalize` can reopen the file with a buffered handle
+    /// for the trailing partial-block write.
+    #[must_use]
+    pub fn new(file: File, path: PathBuf, alignment: usize) -> Self {
+        let capacity = alignment.saturating_mul(BUFFER_BLOCKS).max(alignment);
+        Self {
+            file: Some(file),
+            path,
+            buffer: AlignedBuffer::new(capacity, alignment),
+            buffer_pos: 0,
+            bytes_written: 0,
+            bytes_on_disk: 0,
+            alignment,
+            finalized: false,
+            poisoned: false,
+        }
+    }
+
+    /// Best-effort truncate back to the last successful write boundary after a
+    /// `write_all` partial-write failure. Logs and returns silently on failure;
+    /// the writer is already poisoned at this point.
+    fn truncate_to_last_boundary(file: &File, path: &std::path::Path, target: u64) {
+        if let Err(e) = file.set_len(target) {
+            log::warn!(
+                "AlignedFileWriter: best-effort truncate of {} to {target} after I/O failure failed: {e:?}",
+                path.display(),
+            );
+        }
+    }
+
+    /// Returns an immutable reference to the underlying file, or `None` after
+    /// `finalize`/`cancel` consumed it. Used by callers that need to e.g. query
+    /// the file's metadata while construction is still in progress.
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[must_use]
+    pub fn file(&self) -> Option<&File> {
+        self.file.as_ref()
+    }
+
+    /// Returns the total number of real bytes that have been successfully accepted
+    /// (excluding any padding that will be emitted by `finalize`).
+    #[must_use]
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+
+    /// Drains the trailing partial block (zero-padded to alignment), truncates the
+    /// file to the real byte count, and returns the inner `File`.
+    pub fn finalize(mut self) -> io::Result<File> {
+        self.finalize_in_place()?;
+        #[expect(
+            clippy::expect_used,
+            reason = "self is consumed; file was Some at construction and finalize_in_place did not take it"
+        )]
+        Ok(self.file.take().expect("file should still be present"))
+    }
+
+    /// Releases the inner `File` without writing the trailing partial block and
+    /// without truncating. The on-disk content equals what the last successful
+    /// `spill_aligned` left.
+    ///
+    /// Intended for the "we're about to delete this file anyway" path
+    /// (`table::writer::Writer::finish` with `item_count == 0`).
+    pub fn cancel(mut self) -> File {
+        // Mark finalized so Drop doesn't attempt I/O after we hand the file back.
+        self.finalized = true;
+        #[expect(
+            clippy::expect_used,
+            reason = "self is consumed; file is still Some unless finalize was called, which is not the case here"
+        )]
+        self.file.take().expect("file should still be present")
+    }
+
+    fn finalize_in_place(&mut self) -> io::Result<()> {
+        if self.finalized {
+            return Ok(());
+        }
+        self.finalized = true;
+
+        if self.poisoned {
+            // Don't touch the file in any way: leave it at the last successful
+            // spill boundary so recovery can deal with it.
+            return Ok(());
+        }
+
+        if self.buffer_pos == 0 {
+            // Buffer is empty: nothing to flush, file is already aligned.
+            return Ok(());
+        }
+
+        // All complete aligned chunks have already been spilled to disk via the
+        // direct handle. What remains in the buffer is a single sub-alignment tail
+        // (0 < buffer_pos < alignment in practice, or possibly buffer_pos exactly
+        // == some multiple of alignment if the last spill was deferred — handled
+        // below).
+        let aligned_tail_len = (self.buffer_pos / self.alignment) * self.alignment;
+        if aligned_tail_len > 0 {
+            let Some(file) = self.file.as_mut() else {
+                return Ok(());
+            };
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "aligned_tail_len <= buffer_pos <= capacity"
+            )]
+            if let Err(e) = file.write_all(&self.buffer.as_slice()[..aligned_tail_len]) {
+                Self::truncate_to_last_boundary(file, &self.path, self.bytes_on_disk);
+                self.poisoned = true;
+                return Err(e);
+            }
+            self.bytes_on_disk += aligned_tail_len as u64;
+        }
+
+        let unaligned_tail_len = self.buffer_pos - aligned_tail_len;
+        if unaligned_tail_len > 0 {
+            // Drop the direct-I/O handle before opening the buffered one: avoids
+            // any chance of overlapping cached/uncached state on the same file.
+            drop(self.file.take());
+
+            // Open a buffered handle (no O_DIRECT) in append mode so the write
+            // lands at the current end-of-file — exactly the aligned boundary
+            // the direct handle stopped at.
+            let mut buffered = match std::fs::OpenOptions::new().append(true).open(&self.path) {
+                Ok(f) => f,
+                Err(e) => {
+                    self.poisoned = true;
+                    return Err(e);
+                }
+            };
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "buffer_pos bounded by capacity from the write/spill invariants"
+            )]
+            if let Err(e) = buffered.write_all(
+                &self.buffer.as_slice()[aligned_tail_len..aligned_tail_len + unaligned_tail_len],
+            ) {
+                Self::truncate_to_last_boundary(&buffered, &self.path, self.bytes_on_disk);
+                self.poisoned = true;
+                return Err(e);
+            }
+            self.bytes_on_disk += unaligned_tail_len as u64;
+            self.file = Some(buffered);
+        }
+
+        self.buffer_pos = 0;
+        Ok(())
+    }
+}
+
+impl io::Write for AlignedFileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.poisoned {
+            return Err(io::Error::other(
+                "AlignedFileWriter is poisoned from a previous I/O failure",
+            ));
+        }
+        if self.finalized {
+            return Err(io::Error::other(
+                "AlignedFileWriter is finalized; further writes are not allowed",
+            ));
+        }
+
+        let capacity = self.buffer.capacity();
+        let space = capacity - self.buffer_pos;
+        let to_copy = buf.len().min(space);
+
+        // Indices bounded by `to_copy.min(buf.len(), space)`, all known to fit.
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "to_copy is bounded by both buf.len() and the remaining buffer capacity"
+        )]
+        {
+            self.buffer.as_mut_slice()[self.buffer_pos..self.buffer_pos + to_copy]
+                .copy_from_slice(&buf[..to_copy]);
+        }
+        let new_buffer_pos = self.buffer_pos + to_copy;
+        self.buffer_pos = new_buffer_pos;
+
+        if new_buffer_pos == capacity {
+            // Try to spill the now-full buffer. If the spill fails the in-memory
+            // copy we just did is logically invalid: undo `buffer_pos` and do NOT
+            // credit `bytes_written`, then poison. Bytes already on disk from
+            // previous successful spills remain intact (and `spill_aligned`
+            // has best-effort truncated any partial write back).
+            if let Err(e) = self.spill_aligned() {
+                self.buffer_pos -= to_copy;
+                self.poisoned = true;
+                return Err(e);
+            }
+        }
+        self.bytes_written += to_copy as u64;
+
+        Ok(to_copy)
+    }
+
+    /// Drains the complete aligned chunks accumulated so far. The unaligned tail
+    /// (between 0 and `alignment - 1` bytes) stays in the buffer and is only
+    /// written by `finalize`.
+    ///
+    /// This is a deliberate divergence from `std::io::Write::flush`'s
+    /// "all intermediately buffered contents reach their destination" contract:
+    /// `O_DIRECT` rejects sub-alignment writes, so we cannot honor that contract
+    /// until we know we're done writing.
+    fn flush(&mut self) -> io::Result<()> {
+        if self.poisoned {
+            return Err(io::Error::other(
+                "AlignedFileWriter is poisoned from a previous I/O failure",
+            ));
+        }
+
+        let aligned_len = (self.buffer_pos / self.alignment) * self.alignment;
+        if aligned_len == 0 {
+            return Ok(());
+        }
+
+        let Some(file) = self.file.as_mut() else {
+            return Ok(());
+        };
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "aligned_len <= buffer_pos <= capacity"
+        )]
+        if let Err(e) = file.write_all(&self.buffer.as_slice()[..aligned_len]) {
+            Self::truncate_to_last_boundary(file, &self.path, self.bytes_on_disk);
+            self.poisoned = true;
+            return Err(e);
+        }
+        self.bytes_on_disk += aligned_len as u64;
+
+        // Shift any remaining bytes to the front of the buffer.
+        let tail = self.buffer_pos - aligned_len;
+        if tail > 0 {
+            let buf = self.buffer.as_mut_slice();
+            buf.copy_within(aligned_len..aligned_len + tail, 0);
+        }
+        self.buffer_pos = tail;
+
+        Ok(())
+    }
+}
+
+impl AlignedFileWriter {
+    fn spill_aligned(&mut self) -> io::Result<()> {
+        // Caller guarantees the buffer is full and full == multiple of alignment.
+        debug_assert_eq!(self.buffer_pos % self.alignment, 0);
+
+        let Some(file) = self.file.as_mut() else {
+            return Ok(());
+        };
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "buffer_pos == capacity here per the debug_assert above"
+        )]
+        if let Err(e) = file.write_all(&self.buffer.as_slice()[..self.buffer_pos]) {
+            Self::truncate_to_last_boundary(file, &self.path, self.bytes_on_disk);
+            return Err(e);
+        }
+        self.bytes_on_disk += self.buffer_pos as u64;
+        self.buffer_pos = 0;
+        Ok(())
+    }
+}
+
+impl Drop for AlignedFileWriter {
+    fn drop(&mut self) {
+        // If the caller didn't finalize/cancel and we're not poisoned, try to flush
+        // the tail and truncate. A failure here means the file may be left with up
+        // to one alignment unit of trailing zeros; log loudly because data integrity
+        // is at stake and the caller has lost the ability to react.
+        if !self.finalized && !self.poisoned {
+            if let Err(e) = self.finalize_in_place() {
+                log::error!(
+                    "AlignedFileWriter dropped without explicit finalize and finalize_in_place failed: {e:?}; \
+                     file may have trailing zero padding",
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use test_log::test;
+
+    fn alignment_for_test() -> usize {
+        // Use a small alignment so tests can exercise sub-block tails without
+        // requiring megabytes of data. Power of two >= 512 is what real platforms
+        // would return.
+        512
+    }
+
+    fn write_via_aligned(path: &std::path::Path, data: &[u8], alignment: usize) -> io::Result<()> {
+        // Open without direct-I/O for the test (the writer logic does not require it
+        // — direct I/O only adds *kernel-level* alignment enforcement, which we don't
+        // need to verify the buffering logic).
+        let file = std::fs::File::create(path)?;
+        let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), alignment);
+        writer.write_all(data)?;
+        writer.finalize()?.sync_all()?;
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_exact_alignment_boundary() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("exact");
+        let align = alignment_for_test();
+        let data = vec![0xAB_u8; align * 3];
+
+        write_via_aligned(&path, &data, align)?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(data, roundtrip);
+        assert_eq!(roundtrip.len() as u64, data.len() as u64);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_unaligned_tail_truncates_correctly() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("tail");
+        let align = alignment_for_test();
+        // 2 full blocks + 17 bytes of tail.
+        let data = (0..(align * 2 + 17))
+            .map(|i| (i as u8).wrapping_mul(31))
+            .collect::<Vec<_>>();
+
+        write_via_aligned(&path, &data, align)?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(data.len(), roundtrip.len());
+        assert_eq!(data, roundtrip);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_smaller_than_one_block() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("small");
+        let align = alignment_for_test();
+        let data = b"hello world".to_vec();
+
+        write_via_aligned(&path, &data, align)?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(data, roundtrip);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_empty() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("empty");
+        let align = alignment_for_test();
+
+        write_via_aligned(&path, &[], align)?;
+
+        let meta = std::fs::metadata(&path)?;
+        assert_eq!(meta.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_many_small_writes() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("many");
+        let align = alignment_for_test();
+
+        let file = std::fs::File::create(&path)?;
+        let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), align);
+        let total = align * 5 + 23;
+        for i in 0..total {
+            writer.write_all(&[(i & 0xFF) as u8])?;
+        }
+        writer.finalize()?.sync_all()?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(roundtrip.len(), total);
+        for (i, &b) in roundtrip.iter().enumerate() {
+            assert_eq!(b, (i & 0xFF) as u8, "mismatch at offset {i}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_flush_preserves_unaligned_tail() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("flush");
+        let align = alignment_for_test();
+
+        let file = std::fs::File::create(&path)?;
+        let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), align);
+        let data: Vec<u8> = (0..(align + 100)).map(|i| (i & 0xFF) as u8).collect();
+        writer.write_all(&data)?;
+        // Flush should emit the first aligned block; the 100-byte tail stays buffered.
+        writer.flush()?;
+
+        // File size is exactly one aligned block at this point (no truncation yet).
+        let mid_len = std::fs::metadata(&path)?.len();
+        assert_eq!(mid_len, align as u64);
+
+        writer.finalize()?.sync_all()?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(data, roundtrip);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_drop_without_finalize_does_not_lose_data() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("drop");
+        let align = alignment_for_test();
+        let data = b"unflushed data".to_vec();
+
+        {
+            let file = std::fs::File::create(&path)?;
+            let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), align);
+            writer.write_all(&data)?;
+            // Drop without calling finalize.
+        }
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(data, roundtrip);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_finalize_is_idempotent() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("idem");
+        let align = alignment_for_test();
+
+        let file = std::fs::File::create(&path)?;
+        let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), align);
+        writer.write_all(b"abc")?;
+        writer.finalize_in_place()?;
+        writer.finalize_in_place()?;
+        // Final on already-finalized: should also succeed.
+        let f = writer.finalize()?;
+        f.sync_all()?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(b"abc", &*roundtrip);
+        Ok(())
+    }
+
+    #[test]
+    fn aligned_writer_cancel_does_not_pad_or_truncate() -> io::Result<()> {
+        // cancel is the "we're going to delete this file anyway" path used by
+        // Writer::finish on empty-table. It must not extend the file with padding
+        // (which would waste an fs call and could leave behind a poisoned file if
+        // the caller's later remove_file fails).
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("cancel");
+        let align = alignment_for_test();
+
+        let file = std::fs::File::create(&path)?;
+        let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), align);
+        // Write less than one aligned block: nothing has been spilled to disk yet.
+        writer.write_all(b"some bytes that never get spilled")?;
+        let file = writer.cancel();
+        drop(file);
+
+        // The on-disk file is empty (no spill happened, no finalize, no padding).
+        assert_eq!(std::fs::metadata(&path)?.len(), 0);
+        Ok(())
+    }
+
+    /// Drives the spill path by writing more than one buffer capacity worth of
+    /// bytes, then verifies `bytes_written` and the on-disk file are consistent.
+    /// The buffer capacity is `BUFFER_BLOCKS * alignment`, so we need to push
+    /// at least that much to force `spill_aligned`.
+    #[test]
+    fn aligned_writer_triggers_spill_at_capacity_boundary() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("spill");
+        let align = alignment_for_test();
+        let capacity = align * BUFFER_BLOCKS;
+        // Two full buffer-capacity spills plus a partial tail.
+        let data: Vec<u8> = (0..(capacity * 2 + align + 7))
+            .map(|i| (i & 0xFF) as u8)
+            .collect();
+
+        let file = std::fs::File::create(&path)?;
+        let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), align);
+        writer.write_all(&data)?;
+        assert_eq!(writer.bytes_written(), data.len() as u64);
+        assert!(writer.file().is_some());
+        writer.finalize()?.sync_all()?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(data, roundtrip);
+        Ok(())
+    }
+
+    /// Open the backing file read-only so any write at the kernel level fails
+    /// with `EBADF`. This deterministically exercises the poison path without
+    /// having to inject a custom `Write` impl.
+    #[test]
+    fn aligned_writer_poisons_on_write_failure_and_refuses_subsequent_ops() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("ro");
+        // Create the file as empty so the read-only open succeeds.
+        drop(std::fs::File::create(&path)?);
+        let ro = std::fs::OpenOptions::new().read(true).open(&path)?;
+
+        let align = alignment_for_test();
+        let capacity = align * BUFFER_BLOCKS;
+        let mut writer = AlignedFileWriter::new(ro, path.to_path_buf(), align);
+        // First write fills exactly the buffer and triggers `spill_aligned`,
+        // which calls `write_all` on the read-only handle and fails.
+        let data = vec![0u8; capacity];
+        assert!(writer.write_all(&data).is_err());
+        // Subsequent writes return Err without touching the file.
+        assert!(writer.write(b"more").is_err());
+        // Flush is also refused.
+        assert!(writer.flush().is_err());
+        // Finalize is a no-op in the poisoned state (returns Ok, file unchanged).
+        let f = writer.finalize()?;
+        drop(f);
+        assert_eq!(std::fs::metadata(&path)?.len(), 0);
+        Ok(())
+    }
+
+    /// Verifies the documented invariant: after a write failure, the on-disk
+    /// file size does not exceed the last successful write boundary. We can
+    /// approximate this by opening the file read-only (so the very first spill
+    /// fails) and confirming the file remains at its pre-spill length of zero.
+    #[test]
+    fn aligned_writer_truncates_to_last_boundary_on_failure() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("trunc");
+        drop(std::fs::File::create(&path)?);
+        let ro = std::fs::OpenOptions::new().read(true).open(&path)?;
+
+        let align = alignment_for_test();
+        let capacity = align * BUFFER_BLOCKS;
+        let mut writer = AlignedFileWriter::new(ro, path.to_path_buf(), align);
+        let data = vec![0u8; capacity];
+        let _ = writer.write_all(&data);
+        // bytes_on_disk should still be 0 (no successful spill).
+        // Indirectly: the file size must match.
+        assert_eq!(std::fs::metadata(&path)?.len(), 0);
+        Ok(())
+    }
+}

--- a/src/direct_io/aligned_writer.rs
+++ b/src/direct_io/aligned_writer.rs
@@ -5,8 +5,8 @@
 use super::{aligned_buffer::AlignedBuffer, BUFFER_BLOCKS};
 use std::{
     fs::File,
-    io::{self, Write},
-    path::PathBuf,
+    io::{self, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
 };
 
 /// Buffered writer that emits aligned, page-sized chunks to the underlying file.
@@ -20,6 +20,17 @@ use std::{
 /// handle (opened without `O_DIRECT`). The alternative — writing a zero-padded
 /// block + `ftruncate` — leaks a short window where the file is larger than its
 /// logical content.
+///
+/// ## Runtime fallback
+///
+/// The open-time probe in `chunked` catches filesystems that reject `O_DIRECT`
+/// at open (tmpfs / overlayfs / many FUSE). A few filesystems accept `O_DIRECT`
+/// at open but reject the actual writes (`EINVAL`/`EOPNOTSUPP`), and a device
+/// whose logical block size exceeds the page-size alignment would do the same.
+/// On such a runtime rejection the writer transparently drops `O_DIRECT` (via
+/// `fcntl`) and replays the write buffered from the last durable boundary, so
+/// the flush/compaction completes instead of hard-failing. This mirrors the
+/// reader's runtime fallback.
 ///
 /// ## Error semantics
 ///
@@ -59,6 +70,10 @@ impl AlignedFileWriter {
     /// for the trailing partial-block write.
     #[must_use]
     pub fn new(file: File, path: PathBuf, alignment: usize) -> Self {
+        debug_assert!(
+            alignment.is_power_of_two(),
+            "AlignedFileWriter alignment ({alignment}) must be a non-zero power of two",
+        );
         let capacity = alignment.saturating_mul(BUFFER_BLOCKS).max(alignment);
         Self {
             file: Some(file),
@@ -76,13 +91,58 @@ impl AlignedFileWriter {
     /// Best-effort truncate back to the last successful write boundary after a
     /// `write_all` partial-write failure. Logs and returns silently on failure;
     /// the writer is already poisoned at this point.
-    fn truncate_to_last_boundary(file: &File, path: &std::path::Path, target: u64) {
+    fn truncate_to_last_boundary(file: &File, path: &Path, target: u64) {
         if let Err(e) = file.set_len(target) {
             log::warn!(
                 "AlignedFileWriter: best-effort truncate of {} to {target} after I/O failure failed: {e:?}",
                 path.display(),
             );
         }
+    }
+
+    /// Writes `buf` through the (`O_DIRECT`) handle, transparently falling back to
+    /// buffered I/O if the kernel rejects the direct write at runtime with
+    /// `EINVAL`/`EOPNOTSUPP`.
+    ///
+    /// This covers filesystems that accept `O_DIRECT` at open but reject writes
+    /// (some FUSE/overlay configurations) and devices whose logical block size
+    /// exceeds the page-size alignment — cases the open-time probe cannot detect.
+    /// `boundary` is the last durable file length: on a direct-write rejection we
+    /// truncate back to it (undoing any partial write) and replay `buf` buffered
+    /// from that offset, so no bytes are lost or double-written. After this the
+    /// handle is no longer `O_DIRECT`, so later writes proceed buffered too.
+    ///
+    /// On the happy path (no rejection) this is exactly `file.write_all(buf)`.
+    fn write_all_direct_or_fallback(
+        file: &mut File,
+        path: &Path,
+        boundary: u64,
+        buf: &[u8],
+    ) -> io::Result<()> {
+        #[cfg(all(target_os = "linux", debug_assertions))]
+        let direct_result = if take_forced_write_einval() {
+            Err(io::Error::from_raw_os_error(libc::EINVAL))
+        } else {
+            file.write_all(buf)
+        };
+        #[cfg(not(all(target_os = "linux", debug_assertions)))]
+        let direct_result = file.write_all(buf);
+
+        match direct_result {
+            Ok(()) => return Ok(()),
+            Err(e) if super::is_runtime_direct_io_unsupported(&e) => {
+                log_runtime_fallback_once(path, &e);
+            }
+            Err(e) => return Err(e),
+        }
+
+        // Direct write rejected at runtime: undo any partial write, drop O_DIRECT,
+        // and replay the (already-aligned, but now alignment-irrelevant) buffer
+        // buffered from the last durable boundary.
+        file.set_len(boundary)?;
+        disable_direct_io_for_writer(file)?;
+        file.seek(SeekFrom::Start(boundary))?;
+        file.write_all(buf)
     }
 
     /// Returns an immutable reference to the underlying file, or `None` after
@@ -157,14 +217,26 @@ impl AlignedFileWriter {
         // below).
         let aligned_tail_len = (self.buffer_pos / self.alignment) * self.alignment;
         if aligned_tail_len > 0 {
+            // `file` is always `Some` here: the only paths that take it
+            // (`finalize`/`cancel`) set `finalized`, which short-circuits at the
+            // top of this function. Treat `None` as a hard error rather than
+            // silently dropping the tail (which would mismatch `finalize`'s take).
             let Some(file) = self.file.as_mut() else {
-                return Ok(());
+                self.poisoned = true;
+                return Err(io::Error::other(
+                    "AlignedFileWriter: file handle missing during finalize",
+                ));
             };
             #[expect(
                 clippy::indexing_slicing,
                 reason = "aligned_tail_len <= buffer_pos <= capacity"
             )]
-            if let Err(e) = file.write_all(&self.buffer.as_slice()[..aligned_tail_len]) {
+            if let Err(e) = Self::write_all_direct_or_fallback(
+                file,
+                &self.path,
+                self.bytes_on_disk,
+                &self.buffer.as_slice()[..aligned_tail_len],
+            ) {
                 Self::truncate_to_last_boundary(file, &self.path, self.bytes_on_disk);
                 self.poisoned = true;
                 return Err(e);
@@ -271,6 +343,11 @@ impl io::Write for AlignedFileWriter {
                 "AlignedFileWriter is poisoned from a previous I/O failure",
             ));
         }
+        if self.finalized {
+            // After finalize/cancel the buffer is drained and the file may be
+            // taken; nothing to flush. Mirrors the `finalized` guard in `write`.
+            return Ok(());
+        }
 
         let aligned_len = (self.buffer_pos / self.alignment) * self.alignment;
         if aligned_len == 0 {
@@ -284,7 +361,12 @@ impl io::Write for AlignedFileWriter {
             clippy::indexing_slicing,
             reason = "aligned_len <= buffer_pos <= capacity"
         )]
-        if let Err(e) = file.write_all(&self.buffer.as_slice()[..aligned_len]) {
+        if let Err(e) = Self::write_all_direct_or_fallback(
+            file,
+            &self.path,
+            self.bytes_on_disk,
+            &self.buffer.as_slice()[..aligned_len],
+        ) {
             Self::truncate_to_last_boundary(file, &self.path, self.bytes_on_disk);
             self.poisoned = true;
             return Err(e);
@@ -315,7 +397,12 @@ impl AlignedFileWriter {
             clippy::indexing_slicing,
             reason = "buffer_pos == capacity here per the debug_assert above"
         )]
-        if let Err(e) = file.write_all(&self.buffer.as_slice()[..self.buffer_pos]) {
+        if let Err(e) = Self::write_all_direct_or_fallback(
+            file,
+            &self.path,
+            self.bytes_on_disk,
+            &self.buffer.as_slice()[..self.buffer_pos],
+        ) {
             Self::truncate_to_last_boundary(file, &self.path, self.bytes_on_disk);
             return Err(e);
         }
@@ -323,6 +410,62 @@ impl AlignedFileWriter {
         self.buffer_pos = 0;
         Ok(())
     }
+}
+
+/// Clears `O_DIRECT` from the writer's fd so the rest of the file is written
+/// buffered. No-op on non-Linux (the aligned path is Linux-only).
+#[cfg(target_os = "linux")]
+fn disable_direct_io_for_writer(file: &File) -> io::Result<()> {
+    super::linux::disable_direct_io(file)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "matches the Linux helper signature so the write path has one call site"
+)]
+fn disable_direct_io_for_writer(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+/// Warns a single time per process when a write falls back from direct to
+/// buffered I/O at runtime, so a misconfigured filesystem doesn't flood logs.
+fn log_runtime_fallback_once(path: &Path, e: &io::Error) {
+    use std::sync::OnceLock;
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        log::warn!(
+            "direct I/O write rejected at runtime (first observed at {}: {e}); \
+             disabling O_DIRECT and continuing with buffered I/O for affected files.",
+            path.display(),
+        );
+    });
+}
+
+// Debug-only (Linux) test hook: when armed via `arm_forced_write_einval`, the
+// next direct write simulates an `EINVAL` rejection so the runtime
+// buffered-fallback path can be exercised deterministically without a real
+// O_DIRECT-rejecting filesystem. One-shot per arming; never compiled into
+// release builds.
+#[cfg(all(target_os = "linux", debug_assertions))]
+thread_local! {
+    static FORCE_WRITE_EINVAL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+fn take_forced_write_einval() -> bool {
+    FORCE_WRITE_EINVAL.with(|c| {
+        let armed = c.get();
+        if armed {
+            c.set(false);
+        }
+        armed
+    })
+}
+
+#[cfg(all(test, target_os = "linux", debug_assertions))]
+fn arm_forced_write_einval() {
+    FORCE_WRITE_EINVAL.with(|c| c.set(true));
 }
 
 impl Drop for AlignedFileWriter {
@@ -618,6 +761,39 @@ mod tests {
         // bytes_on_disk should still be 0 (no successful spill).
         // Indirectly: the file size must match.
         assert_eq!(std::fs::metadata(&path)?.len(), 0);
+        Ok(())
+    }
+
+    /// The runtime fallback: when a direct write is rejected mid-stream
+    /// (simulated via the debug-only injection), the writer drops `O_DIRECT` and
+    /// replays buffered from the last boundary, so the data still round-trips
+    /// intact and the file ends at exactly the real byte count. Linux + debug
+    /// only (the injection is compiled out otherwise).
+    #[cfg(all(target_os = "linux", debug_assertions))]
+    #[test]
+    fn aligned_writer_falls_back_to_buffered_on_runtime_einval() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("runtime-fallback");
+        let align = alignment_for_test();
+        let capacity = align * BUFFER_BLOCKS;
+        // Enough to force a spill (the first direct write, which the injection
+        // rejects) plus a sub-alignment tail.
+        let data: Vec<u8> = (0..(capacity + align + 7))
+            .map(|i| (i & 0xFF) as u8)
+            .collect();
+
+        let file = std::fs::File::create(&path)?;
+        let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), align);
+        super::arm_forced_write_einval();
+        writer.write_all(&data)?;
+        writer.finalize()?.sync_all()?;
+
+        let mut roundtrip = vec![];
+        std::fs::File::open(&path)?.read_to_end(&mut roundtrip)?;
+        assert_eq!(
+            roundtrip, data,
+            "data must survive the runtime buffered fallback"
+        );
         Ok(())
     }
 }

--- a/src/direct_io/aligned_writer.rs
+++ b/src/direct_io/aligned_writer.rs
@@ -9,36 +9,34 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Buffered writer that emits aligned, page-sized chunks to the underlying file.
+/// Writer that emits aligned, block-sized chunks to an `O_DIRECT` file.
 ///
 /// `O_DIRECT` requires the buffer pointer, file offset, and length to all be
-/// multiples of the device's logical block size. This writer accumulates incoming
-/// bytes into an aligned heap buffer and only emits full, aligned chunks until
+/// multiples of the device's logical block size. This writer accumulates bytes
+/// into an aligned heap buffer and only emits full, aligned chunks until
 /// `finalize` is called.
 ///
-/// `finalize` writes the (possibly partial) trailing block via a separate buffered
-/// handle (opened without `O_DIRECT`). The alternative — writing a zero-padded
-/// block + `ftruncate` — leaks a short window where the file is larger than its
-/// logical content.
+/// `finalize` writes the (possibly partial) trailing block through a separate
+/// buffered handle (no `O_DIRECT`). The alternative, a zero-padded block plus
+/// `ftruncate`, leaves a brief window where the file is larger than its content.
 ///
 /// ## Runtime fallback
 ///
 /// The open-time probe in `chunked` catches filesystems that reject `O_DIRECT`
-/// at open (tmpfs / overlayfs / many FUSE). A few filesystems accept `O_DIRECT`
-/// at open but reject the actual writes (`EINVAL`/`EOPNOTSUPP`), and a device
-/// whose logical block size exceeds the page-size alignment would do the same.
-/// On such a runtime rejection the writer transparently drops `O_DIRECT` (via
-/// `fcntl`) and replays the write buffered from the last durable boundary, so
-/// the flush/compaction completes instead of hard-failing. This mirrors the
-/// reader's runtime fallback.
+/// at open (tmpfs / overlayfs / many FUSE). A few accept the open but reject the
+/// writes (`EINVAL`/`EOPNOTSUPP`), and a device whose logical block size exceeds
+/// the page-size alignment would too. On such a runtime rejection the writer
+/// drops `O_DIRECT` (via `fcntl`) and replays the write buffered from the last
+/// durable boundary, so the flush/compaction finishes instead of failing. This
+/// mirrors the reader's runtime fallback.
 ///
 /// ## Error semantics
 ///
 /// If any `Write::write` or `Write::flush` call returns an error, the writer enters
 /// a *poisoned* state: all subsequent write/flush/finalize calls return an error
-/// without touching the file. The on-disk file is left containing exactly the bytes
-/// from the last successful aligned spill — never extended beyond what made it to
-/// disk. Drop in the poisoned state is a no-op.
+/// without touching the file. The on-disk file keeps exactly the bytes from the
+/// last successful aligned spill, never extended beyond what reached disk. Drop in
+/// the poisoned state is a no-op.
 pub struct AlignedFileWriter {
     /// `Option` so `finalize` / `cancel` can take ownership of the file out of the
     /// struct even though `AlignedFileWriter` implements `Drop`. `None` only between
@@ -51,7 +49,7 @@ pub struct AlignedFileWriter {
     /// Bytes currently buffered (between 0 and `buffer.capacity()`).
     buffer_pos: usize,
     /// Total real bytes written and accepted (never includes bytes from a failed
-    /// spill — see `Self::write`).
+    /// spill; see `Self::write`).
     bytes_written: u64,
     /// File size at the last successful write completion. On any `write_all`
     /// failure we best-effort `set_len(bytes_on_disk)` so the on-disk file does
@@ -100,19 +98,18 @@ impl AlignedFileWriter {
         }
     }
 
-    /// Writes `buf` through the (`O_DIRECT`) handle, transparently falling back to
-    /// buffered I/O if the kernel rejects the direct write at runtime with
-    /// `EINVAL`/`EOPNOTSUPP`.
+    /// Writes `buf` through the `O_DIRECT` handle, falling back to buffered I/O
+    /// if the kernel rejects the direct write at runtime with `EINVAL`/`EOPNOTSUPP`.
     ///
     /// This covers filesystems that accept `O_DIRECT` at open but reject writes
-    /// (some FUSE/overlay configurations) and devices whose logical block size
-    /// exceeds the page-size alignment — cases the open-time probe cannot detect.
-    /// `boundary` is the last durable file length: on a direct-write rejection we
-    /// truncate back to it (undoing any partial write) and replay `buf` buffered
-    /// from that offset, so no bytes are lost or double-written. After this the
-    /// handle is no longer `O_DIRECT`, so later writes proceed buffered too.
+    /// (some FUSE/overlay setups) and devices whose logical block size exceeds the
+    /// page-size alignment, cases the open-time probe cannot detect. `boundary` is
+    /// the last durable file length: on a rejection we truncate back to it (undoing
+    /// any partial write) and replay `buf` buffered from that offset, so nothing is
+    /// lost or double-written. The handle is no longer `O_DIRECT` afterwards, so
+    /// later writes stay buffered too.
     ///
-    /// On the happy path (no rejection) this is exactly `file.write_all(buf)`.
+    /// On the happy path (no rejection) this is just `file.write_all(buf)`.
     fn write_all_direct_or_fallback(
         file: &mut File,
         path: &Path,
@@ -154,8 +151,8 @@ impl AlignedFileWriter {
         self.file.as_ref()
     }
 
-    /// Returns the total number of real bytes that have been successfully accepted
-    /// (excluding any padding that will be emitted by `finalize`).
+    /// Returns the total real bytes accepted so far, which equals the final file
+    /// size (some may still be buffered, not yet on disk).
     #[must_use]
     pub fn bytes_written(&self) -> u64 {
         self.bytes_written
@@ -164,10 +161,9 @@ impl AlignedFileWriter {
     /// Drains the trailing partial block and returns the inner `File`.
     ///
     /// Any complete aligned chunks still buffered are written via the direct
-    /// handle; the final sub-alignment tail (if any) is written through a
-    /// separate buffered (non-`O_DIRECT`) handle so the file ends at exactly the
-    /// real byte count — no zero padding is ever persisted and no `set_len` is
-    /// needed.
+    /// handle; the final sub-alignment tail (if any) goes through a separate
+    /// buffered (non-`O_DIRECT`) handle, so the file ends at exactly the real
+    /// byte count. No zero padding is persisted and no `set_len` is needed.
     pub fn finalize(mut self) -> io::Result<File> {
         self.finalize_in_place()?;
         #[expect(
@@ -210,11 +206,10 @@ impl AlignedFileWriter {
             return Ok(());
         }
 
-        // All complete aligned chunks have already been spilled to disk via the
-        // direct handle. What remains in the buffer is a single sub-alignment tail
-        // (0 < buffer_pos < alignment in practice, or possibly buffer_pos exactly
-        // == some multiple of alignment if the last spill was deferred — handled
-        // below).
+        // All complete aligned chunks have already spilled to disk via the direct
+        // handle. What's left in the buffer is the sub-alignment tail (usually
+        // 0 < buffer_pos < alignment, but possibly a multiple of alignment if the
+        // last spill was deferred; both are handled below).
         let aligned_tail_len = (self.buffer_pos / self.alignment) * self.alignment;
         if aligned_tail_len > 0 {
             // `file` is always `Some` here: the only paths that take it
@@ -251,7 +246,7 @@ impl AlignedFileWriter {
             drop(self.file.take());
 
             // Open a buffered handle (no O_DIRECT) in append mode so the write
-            // lands at the current end-of-file — exactly the aligned boundary
+            // lands at the current end-of-file, which is the aligned boundary
             // the direct handle stopped at.
             let mut buffered = match std::fs::OpenOptions::new().append(true).open(&self.path) {
                 Ok(f) => f,
@@ -470,12 +465,11 @@ fn arm_forced_write_einval() {
 
 impl Drop for AlignedFileWriter {
     fn drop(&mut self) {
-        // If the caller didn't finalize/cancel and we're not poisoned, try to drain
-        // the tail. A failure here means the file may be left missing up to one
-        // alignment unit of trailing bytes (the unwritten sub-alignment tail); log
-        // loudly because data integrity is at stake and the caller has lost the
-        // ability to react. Note: Drop-time finalization is best-effort and does
-        // not fsync — production paths must call `finalize()` explicitly.
+        // If the caller didn't finalize/cancel and we're not poisoned, drain the
+        // tail. A failure here can leave the file missing its sub-alignment tail
+        // (up to one alignment unit), so log loudly: data integrity is at stake
+        // and the caller can't react. Drop-time finalization is best-effort and
+        // does not fsync; production paths must call `finalize()` explicitly.
         if !self.finalized && !self.poisoned {
             if let Err(e) = self.finalize_in_place() {
                 log::error!(
@@ -501,9 +495,9 @@ mod tests {
     }
 
     fn write_via_aligned(path: &std::path::Path, data: &[u8], alignment: usize) -> io::Result<()> {
-        // Open without direct-I/O for the test (the writer logic does not require it
-        // — direct I/O only adds *kernel-level* alignment enforcement, which we don't
-        // need to verify the buffering logic).
+        // Open without direct I/O for the test. The writer logic doesn't require
+        // it; O_DIRECT only adds kernel-level alignment enforcement, which we
+        // don't need to verify the buffering logic.
         let file = std::fs::File::create(path)?;
         let mut writer = AlignedFileWriter::new(file, path.to_path_buf(), alignment);
         writer.write_all(data)?;

--- a/src/direct_io/chunked.rs
+++ b/src/direct_io/chunked.rs
@@ -37,16 +37,13 @@ const DEFAULT_READER_CAPACITY: usize = 8 * 4_096;
 /// is rejected by the underlying filesystem (commonly tmpfs / overlayfs / FUSE).
 /// Callers should silently fall back to buffered I/O on this error.
 ///
-/// O_DIRECT-unsupported is reported as `EINVAL` by most filesystems (tmpfs,
+/// Lack of `O_DIRECT` support is reported as `EINVAL` by most filesystems (tmpfs,
 /// overlayfs), but some network/FUSE filesystems use `EOPNOTSUPP` (== `ENOTSUP`
 /// on Linux). Both are treated as "fall back to buffered" so a flush/compaction
-/// is never hard-failed by a filesystem that simply lacks O_DIRECT.
+/// is never hard-failed by a filesystem that simply lacks direct I/O.
 #[cfg(target_os = "linux")]
 fn is_direct_io_unsupported(e: &io::Error) -> bool {
-    matches!(
-        e.raw_os_error(),
-        Some(libc::EINVAL) | Some(libc::EOPNOTSUPP)
-    )
+    matches!(e.raw_os_error(), Some(libc::EINVAL | libc::EOPNOTSUPP))
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/direct_io/chunked.rs
+++ b/src/direct_io/chunked.rs
@@ -13,9 +13,9 @@
 //!
 //! - **Linux**: aligned-buffer backend with `O_DIRECT` at open time. If the
 //!   filesystem rejects `O_DIRECT` (`EINVAL` on tmpfs / overlayfs / some FUSE),
-//!   the open transparently falls back to buffered with a single `log::warn`.
+//!   the open falls back to buffered with a single `log::warn`.
 //! - **macOS**: regular `BufWriter`/`BufReader` over a file with `F_NOCACHE`
-//!   applied — `F_NOCACHE` has no alignment requirement, so the aligned-buffer
+//!   applied. `F_NOCACHE` has no alignment requirement, so the aligned-buffer
 //!   machinery is not needed.
 //! - **Other** (including Windows): regular buffered I/O; the flag is a no-op.
 
@@ -51,12 +51,12 @@ fn is_direct_io_unsupported(_e: &io::Error) -> bool {
     false
 }
 
-/// Buffered writer that transparently uses direct I/O when requested.
+/// Writer that uses direct I/O when requested, buffered otherwise.
 pub enum ChunkedWriter {
     /// Standard buffered path: `BufWriter<File>` exactly as before.
     Buffered(BufWriter<File>),
 
-    /// Aligned-buffer direct I/O path. Linux only — macOS uses `F_NOCACHE`
+    /// Aligned-buffer direct I/O path. Linux only; macOS uses `F_NOCACHE`,
     /// which needs no alignment, so it stays on the buffered variant.
     #[cfg(target_os = "linux")]
     Aligned(AlignedFileWriter),
@@ -66,18 +66,14 @@ impl ChunkedWriter {
     /// Opens (creates new) a file for writing.
     ///
     /// `direct` requests `O_DIRECT` (Linux) or `F_NOCACHE` (macOS); a no-op on
-    /// other platforms. If the filesystem rejects the direct-I/O flag, this
-    /// transparently falls back to buffered I/O with a single `log::warn`.
+    /// other platforms. If the filesystem rejects direct I/O, the open falls
+    /// back to buffered with a single `log::warn`.
     pub fn create_new(path: &Path, direct: bool) -> io::Result<Self> {
         Self::create_new_with_capacity(path, direct, DEFAULT_BUF_CAPACITY)
     }
 
-    /// Like [`Self::create_new`] but for paths where `File::create` (truncate)
-    /// semantics are needed (blob file writer).
-    ///
-    /// `direct` requests `O_DIRECT` (Linux) or `F_NOCACHE` (macOS); a no-op on
-    /// other platforms. If the filesystem rejects the direct-I/O flag, this
-    /// transparently falls back to buffered I/O with a single `log::warn`.
+    /// Like [`Self::create_new`] but with `File::create` (truncate) semantics,
+    /// for the blob file writer. Same direct-I/O fallback behavior.
     pub fn create_or_truncate(path: &Path, direct: bool) -> io::Result<Self> {
         Self::create_or_truncate_with_capacity(path, direct, DEFAULT_BUF_CAPACITY)
     }
@@ -163,8 +159,8 @@ impl ChunkedWriter {
     #[cfg(not(target_os = "linux"))]
     fn open_direct_write(path: &Path, capacity: usize, truncate: bool) -> io::Result<Self> {
         // macOS / fallback: the platform open applies F_NOCACHE post-open (macOS)
-        // or is a plain buffered open (fallback). Both work fine wrapped in a
-        // regular BufWriter — no alignment requirement.
+        // or is a plain buffered open (fallback). Both work in a regular
+        // BufWriter; no alignment requirement.
         let file = if truncate {
             super::create_or_truncate_write_direct(path)?
         } else {
@@ -254,7 +250,7 @@ impl Seek for ChunkedWriter {
     }
 }
 
-/// Buffered reader that transparently uses direct I/O when requested.
+/// Reader that uses direct I/O when requested, buffered otherwise.
 pub enum ChunkedReader {
     Buffered(BufReader<File>),
 
@@ -265,8 +261,8 @@ pub enum ChunkedReader {
 impl ChunkedReader {
     /// Opens an existing file for reading.
     ///
-    /// If `direct` is true but the filesystem rejects the direct-I/O flag, this
-    /// transparently falls back to buffered I/O with a single `log::warn`.
+    /// If `direct` is set but the filesystem rejects direct I/O, the open falls
+    /// back to buffered with a single `log::warn`.
     pub fn open(path: &Path, direct: bool) -> io::Result<Self> {
         Self::open_with_capacity(path, direct, DEFAULT_READER_CAPACITY)
     }
@@ -376,9 +372,8 @@ mod tests {
     fn chunked_writer_roundtrip_direct() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("a");
-        // With the fallback in place this should always succeed: direct I/O is
-        // attempted first, and if EINVAL/ERROR_INVALID_PARAMETER is returned the
-        // open transparently falls back to buffered.
+        // With the fallback in place this always succeeds: direct I/O is tried
+        // first, and if the filesystem rejects it the open falls back to buffered.
         let mut w = ChunkedWriter::create_new(&path, true)?;
         w.write_all(b"hello")?;
         w.finalize()?.sync_all()?;

--- a/src/direct_io/chunked.rs
+++ b/src/direct_io/chunked.rs
@@ -1,0 +1,425 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! Buffered file I/O with optional direct-I/O backing.
+//!
+//! [`ChunkedWriter`] and [`ChunkedReader`] expose the same `Write` / `Read` API as
+//! `BufWriter<File>` / `BufReader<File>`, but pick the aligned backend when the
+//! caller asks for direct I/O. Call sites in `table::writer`, `multi_writer`,
+//! `table::scanner`, etc. only have to flip a bool to switch modes.
+//!
+//! Per-platform routing:
+//!
+//! - **Linux**: aligned-buffer backend with `O_DIRECT` at open time. If the
+//!   filesystem rejects `O_DIRECT` (`EINVAL` on tmpfs / overlayfs / some FUSE),
+//!   the open transparently falls back to buffered with a single `log::warn`.
+//! - **macOS**: regular `BufWriter`/`BufReader` over a file with `F_NOCACHE`
+//!   applied — `F_NOCACHE` has no alignment requirement, so the aligned-buffer
+//!   machinery is not needed.
+//! - **Other** (including Windows): regular buffered I/O; the flag is a no-op.
+
+#[cfg(target_os = "linux")]
+use super::{AlignedFileReader, AlignedFileWriter};
+use std::{
+    fs::File,
+    io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write},
+    path::Path,
+};
+
+/// Default buffer size for `BufWriter` used by the table writer pre-existing code path.
+/// `u16::MAX + 1` matches the value used before this module existed.
+const DEFAULT_BUF_CAPACITY: usize = u16::MAX as usize + 1;
+
+/// Default buffer capacity for `BufReader` used by the table scanner.
+/// Matches the prior literal `8 * 4_096` constant.
+const DEFAULT_READER_CAPACITY: usize = 8 * 4_096;
+
+/// Returns `true` when the error indicates the platform's direct-I/O primitive
+/// is rejected by the underlying filesystem (commonly tmpfs / overlayfs / FUSE).
+/// Callers should silently fall back to buffered I/O on this error.
+#[cfg(target_os = "linux")]
+fn is_direct_io_unsupported(e: &io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EINVAL)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_direct_io_unsupported(_e: &io::Error) -> bool {
+    false
+}
+
+/// Buffered writer that transparently uses direct I/O when requested.
+pub enum ChunkedWriter {
+    /// Standard buffered path: `BufWriter<File>` exactly as before.
+    Buffered(BufWriter<File>),
+
+    /// Aligned-buffer direct I/O path. Linux only — macOS uses `F_NOCACHE`
+    /// which needs no alignment, so it stays on the buffered variant.
+    #[cfg(target_os = "linux")]
+    Aligned(AlignedFileWriter),
+}
+
+impl ChunkedWriter {
+    /// Opens (creates new) a file for writing.
+    ///
+    /// `direct` requests `O_DIRECT` (Linux) or `F_NOCACHE` (macOS); a no-op on
+    /// other platforms. If the filesystem rejects the direct-I/O flag, this
+    /// transparently falls back to buffered I/O with a single `log::warn`.
+    pub fn create_new(path: &Path, direct: bool) -> io::Result<Self> {
+        Self::create_new_with_capacity(path, direct, DEFAULT_BUF_CAPACITY)
+    }
+
+    /// Like [`Self::create_new`] but for paths where `File::create` (truncate)
+    /// semantics are needed (blob file writer).
+    pub fn create_or_truncate(path: &Path, direct: bool) -> io::Result<Self> {
+        Self::create_or_truncate_with_capacity(path, direct, DEFAULT_BUF_CAPACITY)
+    }
+
+    fn create_new_with_capacity(path: &Path, direct: bool, capacity: usize) -> io::Result<Self> {
+        if direct {
+            match Self::open_direct_write(path, capacity, false) {
+                Ok(w) => return Ok(w),
+                Err(e) if is_direct_io_unsupported(&e) => {
+                    log_unsupported_once(path, &e);
+                    // Fall through to buffered open below.
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(Self::Buffered(BufWriter::with_capacity(
+            capacity,
+            File::create_new(path)?,
+        )))
+    }
+
+    fn create_or_truncate_with_capacity(
+        path: &Path,
+        direct: bool,
+        capacity: usize,
+    ) -> io::Result<Self> {
+        if direct {
+            match Self::open_direct_write(path, capacity, true) {
+                Ok(w) => return Ok(w),
+                Err(e) if is_direct_io_unsupported(&e) => {
+                    log_unsupported_once(path, &e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(Self::Buffered(BufWriter::with_capacity(
+            capacity,
+            File::create(path)?,
+        )))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn open_direct_write(path: &Path, _capacity: usize, truncate: bool) -> io::Result<Self> {
+        let file = if truncate {
+            super::create_or_truncate_write_direct(path)?
+        } else {
+            super::create_write_direct(path)?
+        };
+        let alignment = super::block_alignment_for(path);
+        Ok(Self::Aligned(AlignedFileWriter::new(
+            file,
+            path.to_path_buf(),
+            alignment,
+        )))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn open_direct_write(path: &Path, capacity: usize, truncate: bool) -> io::Result<Self> {
+        // macOS / fallback: the platform open applies F_NOCACHE post-open (macOS)
+        // or is a plain buffered open (fallback). Both work fine wrapped in a
+        // regular BufWriter — no alignment requirement.
+        let file = if truncate {
+            super::create_or_truncate_write_direct(path)?
+        } else {
+            super::create_write_direct(path)?
+        };
+        Ok(Self::Buffered(BufWriter::with_capacity(capacity, file)))
+    }
+
+    /// Finalizes the writer: drains all buffers (handling the trailing partial
+    /// block in direct mode) and returns the underlying `File`.
+    ///
+    /// The caller is expected to call `sync_all()` on the returned file.
+    pub fn finalize(self) -> io::Result<File> {
+        match self {
+            Self::Buffered(w) => w.into_inner().map_err(std::io::IntoInnerError::into_error),
+            #[cfg(target_os = "linux")]
+            Self::Aligned(w) => w.finalize(),
+        }
+    }
+
+    /// Discards any buffered bytes and returns the inner `File` without writing
+    /// the trailing tail. Intended for paths that will immediately delete the
+    /// file (e.g. an empty-table table writer that decides at finish-time the
+    /// file should not exist).
+    pub fn cancel(self) -> File {
+        match self {
+            Self::Buffered(w) => {
+                // BufWriter::into_parts returns the inner writer plus any unwritten
+                // bytes; we discard both. (BufWriter::into_inner would try to flush
+                // first, which is wasteful when we're about to remove the file.)
+                let (file, _unwritten) = w.into_parts();
+                file
+            }
+            #[cfg(target_os = "linux")]
+            Self::Aligned(w) => w.cancel(),
+        }
+    }
+}
+
+impl Write for ChunkedWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Buffered(w) => w.write(buf),
+            #[cfg(target_os = "linux")]
+            Self::Aligned(w) => w.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Buffered(w) => w.flush(),
+            #[cfg(target_os = "linux")]
+            Self::Aligned(w) => w.flush(),
+        }
+    }
+}
+
+/// `Seek` is implemented for `ChunkedWriter` so that the `sfa::Writer` chain (which
+/// requires `Seek` to call `stream_position` while building its table-of-contents)
+/// compiles.
+///
+/// Only `SeekFrom::Current(0)` (i.e. `stream_position`) is meaningfully supported in
+/// direct-I/O mode, because aligned writes have no random-access semantics until
+/// `finalize` runs. Buffered mode delegates to `BufWriter`, which preserves the
+/// pre-existing behavior.
+impl Seek for ChunkedWriter {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        match self {
+            Self::Buffered(w) => w.seek(pos),
+            #[cfg(target_os = "linux")]
+            Self::Aligned(w) => match pos {
+                SeekFrom::Current(0) => Ok(w.bytes_written()),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "seek other than Current(0) is not supported on direct-I/O writers",
+                )),
+            },
+        }
+    }
+
+    fn stream_position(&mut self) -> io::Result<u64> {
+        match self {
+            Self::Buffered(w) => w.stream_position(),
+            #[cfg(target_os = "linux")]
+            Self::Aligned(w) => Ok(w.bytes_written()),
+        }
+    }
+}
+
+/// Buffered reader that transparently uses direct I/O when requested.
+pub enum ChunkedReader {
+    Buffered(BufReader<File>),
+
+    #[cfg(target_os = "linux")]
+    Aligned(AlignedFileReader),
+}
+
+impl ChunkedReader {
+    /// Opens an existing file for reading.
+    ///
+    /// If `direct` is true but the filesystem rejects the direct-I/O flag, this
+    /// transparently falls back to buffered I/O with a single `log::warn`.
+    pub fn open(path: &Path, direct: bool) -> io::Result<Self> {
+        Self::open_with_capacity(path, direct, DEFAULT_READER_CAPACITY)
+    }
+
+    fn open_with_capacity(path: &Path, direct: bool, capacity: usize) -> io::Result<Self> {
+        if direct {
+            match Self::open_direct(path) {
+                Ok(r) => return Ok(r),
+                Err(e) if is_direct_io_unsupported(&e) => {
+                    log_unsupported_once(path, &e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(Self::Buffered(BufReader::with_capacity(
+            capacity,
+            File::open(path)?,
+        )))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn open_direct(path: &Path) -> io::Result<Self> {
+        let file = super::open_read_direct(path)?;
+        let alignment = super::block_alignment_for(path);
+        Ok(Self::Aligned(AlignedFileReader::new(file, alignment)?))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn open_direct(path: &Path) -> io::Result<Self> {
+        // macOS / fallback: F_NOCACHE has no alignment requirement, so a regular
+        // BufReader on the F_NOCACHE'd file works fine.
+        let file = super::open_read_direct(path)?;
+        Ok(Self::Buffered(BufReader::with_capacity(
+            DEFAULT_READER_CAPACITY,
+            file,
+        )))
+    }
+}
+
+impl Read for ChunkedReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Buffered(r) => r.read(buf),
+            #[cfg(target_os = "linux")]
+            Self::Aligned(r) => r.read(buf),
+        }
+    }
+}
+
+/// Emits a single `warn` per process when a filesystem rejects direct I/O.
+/// Subsequent fallbacks are silent so a tree on tmpfs doesn't flood logs.
+fn log_unsupported_once(path: &Path, e: &io::Error) {
+    use std::sync::OnceLock;
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let path_display = path.display();
+        log::warn!(
+            "direct I/O not supported by filesystem (first observed at {path_display}: {e}); \
+             falling back to buffered I/O. The use_direct_io_for_* config flags will have no effect on this filesystem.",
+        );
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    #[test]
+    fn chunked_writer_roundtrip_buffered() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("a");
+        let mut w = ChunkedWriter::create_new(&path, false)?;
+        w.write_all(b"hello")?;
+        w.finalize()?.sync_all()?;
+
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut ChunkedReader::open(&path, false)?, &mut buf)?;
+        assert_eq!(buf, "hello");
+        Ok(())
+    }
+
+    #[test]
+    fn chunked_writer_roundtrip_direct() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("a");
+        // With the fallback in place this should always succeed: direct I/O is
+        // attempted first, and if EINVAL/ERROR_INVALID_PARAMETER is returned the
+        // open transparently falls back to buffered.
+        let mut w = ChunkedWriter::create_new(&path, true)?;
+        w.write_all(b"hello")?;
+        w.finalize()?.sync_all()?;
+
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut ChunkedReader::open(&path, true)?, &mut buf)?;
+        assert_eq!(buf, "hello");
+        Ok(())
+    }
+
+    #[test]
+    fn chunked_writer_finalize_truncates_to_real_size() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("size");
+
+        let payload = b"123456789".repeat(1_000); // 9_000 bytes
+        let mut w = ChunkedWriter::create_new(&path, true)?;
+        w.write_all(&payload)?;
+        w.finalize()?.sync_all()?;
+
+        let actual_size = std::fs::metadata(&path)?.len();
+        assert_eq!(actual_size, payload.len() as u64);
+        Ok(())
+    }
+
+    #[test]
+    fn chunked_writer_cancel_releases_file_without_padding() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("cancel");
+        let mut w = ChunkedWriter::create_new(&path, false)?;
+        w.write_all(b"to be discarded")?;
+        let file = w.cancel();
+        drop(file);
+        // BufWriter::into_parts discards unwritten bytes; the file may be empty
+        // or contain whatever BufWriter happened to forward (typically nothing
+        // for a small write).
+        std::fs::remove_file(&path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn chunked_writer_stream_position_matches_bytes_written() -> io::Result<()> {
+        use std::io::Seek;
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("pos");
+        let mut w = ChunkedWriter::create_new(&path, false)?;
+        w.write_all(b"abcdefghij")?;
+        let pos = w.stream_position()?;
+        // For the Buffered variant, `stream_position` queries the underlying
+        // `BufWriter::stream_position` which counts bytes written so far. It is
+        // valid for buffered to return anywhere from "what was actually written
+        // to the file" up to "what was written into the buffer".
+        assert!(pos <= 10);
+        Ok(())
+    }
+
+    #[test]
+    fn chunked_writer_create_or_truncate_overwrites_existing() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("trunc");
+        // Pre-existing content.
+        std::fs::write(&path, b"pre-existing")?;
+        let mut w = ChunkedWriter::create_or_truncate(&path, false)?;
+        w.write_all(b"new")?;
+        w.finalize()?.sync_all()?;
+
+        let mut buf = vec![];
+        std::io::Read::read_to_end(&mut ChunkedReader::open(&path, false)?, &mut buf)?;
+        assert_eq!(buf, b"new");
+        Ok(())
+    }
+
+    #[test]
+    fn is_direct_io_unsupported_classifies_einval_on_linux_only() {
+        // Non-Linux platforms have no native O_DIRECT path; the classifier
+        // returns false for every error (the buffered fallback handles things).
+        let einval = io::Error::from_raw_os_error(22);
+        let other = io::Error::other("not an OS error");
+        #[cfg(target_os = "linux")]
+        {
+            assert!(is_direct_io_unsupported(&einval));
+            assert!(!is_direct_io_unsupported(&other));
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert!(!is_direct_io_unsupported(&einval));
+            assert!(!is_direct_io_unsupported(&other));
+        }
+    }
+
+    #[test]
+    fn log_unsupported_once_does_not_panic() {
+        // The function uses a process-wide OnceLock so subsequent calls become
+        // no-ops; calling it here just exercises the branch.
+        let e = io::Error::from_raw_os_error(22);
+        log_unsupported_once(std::path::Path::new("/dev/null"), &e);
+        // Second call to verify the OnceLock idempotency.
+        log_unsupported_once(std::path::Path::new("/dev/null"), &e);
+    }
+}

--- a/src/direct_io/chunked.rs
+++ b/src/direct_io/chunked.rs
@@ -27,20 +27,26 @@ use std::{
     path::Path,
 };
 
-/// Default buffer size for `BufWriter` used by the table writer pre-existing code path.
-/// `u16::MAX + 1` matches the value used before this module existed.
+/// Buffered-mode write buffer capacity for both table and blob file writers.
 const DEFAULT_BUF_CAPACITY: usize = u16::MAX as usize + 1;
 
-/// Default buffer capacity for `BufReader` used by the table scanner.
-/// Matches the prior literal `8 * 4_096` constant.
+/// Buffered-mode read buffer capacity for table and blob scanners.
 const DEFAULT_READER_CAPACITY: usize = 8 * 4_096;
 
 /// Returns `true` when the error indicates the platform's direct-I/O primitive
 /// is rejected by the underlying filesystem (commonly tmpfs / overlayfs / FUSE).
 /// Callers should silently fall back to buffered I/O on this error.
+///
+/// O_DIRECT-unsupported is reported as `EINVAL` by most filesystems (tmpfs,
+/// overlayfs), but some network/FUSE filesystems use `EOPNOTSUPP` (== `ENOTSUP`
+/// on Linux). Both are treated as "fall back to buffered" so a flush/compaction
+/// is never hard-failed by a filesystem that simply lacks O_DIRECT.
 #[cfg(target_os = "linux")]
 fn is_direct_io_unsupported(e: &io::Error) -> bool {
-    e.raw_os_error() == Some(libc::EINVAL)
+    matches!(
+        e.raw_os_error(),
+        Some(libc::EINVAL) | Some(libc::EOPNOTSUPP)
+    )
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -71,16 +77,42 @@ impl ChunkedWriter {
 
     /// Like [`Self::create_new`] but for paths where `File::create` (truncate)
     /// semantics are needed (blob file writer).
+    ///
+    /// `direct` requests `O_DIRECT` (Linux) or `F_NOCACHE` (macOS); a no-op on
+    /// other platforms. If the filesystem rejects the direct-I/O flag, this
+    /// transparently falls back to buffered I/O with a single `log::warn`.
     pub fn create_or_truncate(path: &Path, direct: bool) -> io::Result<Self> {
         Self::create_or_truncate_with_capacity(path, direct, DEFAULT_BUF_CAPACITY)
     }
 
-    fn create_new_with_capacity(path: &Path, direct: bool, capacity: usize) -> io::Result<Self> {
+    fn create_or_truncate_with_capacity(
+        path: &Path,
+        direct: bool,
+        capacity: usize,
+    ) -> io::Result<Self> {
         if direct {
-            match Self::open_direct_write(path, capacity, false) {
+            match Self::direct_write_attempt(path, capacity, true) {
                 Ok(w) => return Ok(w),
                 Err(e) if is_direct_io_unsupported(&e) => {
                     log_unsupported_once(path, &e);
+                    remove_orphan_after_unsupported_open(path);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(Self::Buffered(BufWriter::with_capacity(
+            capacity,
+            File::create(path)?,
+        )))
+    }
+
+    fn create_new_with_capacity(path: &Path, direct: bool, capacity: usize) -> io::Result<Self> {
+        if direct {
+            match Self::direct_write_attempt(path, capacity, false) {
+                Ok(w) => return Ok(w),
+                Err(e) if is_direct_io_unsupported(&e) => {
+                    log_unsupported_once(path, &e);
+                    remove_orphan_after_unsupported_open(path);
                     // Fall through to buffered open below.
                 }
                 Err(e) => return Err(e),
@@ -92,24 +124,28 @@ impl ChunkedWriter {
         )))
     }
 
-    fn create_or_truncate_with_capacity(
-        path: &Path,
-        direct: bool,
-        capacity: usize,
-    ) -> io::Result<Self> {
-        if direct {
-            match Self::open_direct_write(path, capacity, true) {
-                Ok(w) => return Ok(w),
-                Err(e) if is_direct_io_unsupported(&e) => {
-                    log_unsupported_once(path, &e);
-                }
-                Err(e) => return Err(e),
-            }
+    /// Attempts the platform direct-write open, honoring the debug-only test hook
+    /// that simulates a filesystem rejecting `O_DIRECT` (see
+    /// [`should_force_unsupported_open`]).
+    fn direct_write_attempt(path: &Path, capacity: usize, truncate: bool) -> io::Result<Self> {
+        #[cfg(all(target_os = "linux", debug_assertions))]
+        if should_force_unsupported_open() {
+            // Faithfully reproduce the kernel behavior the fallback must survive:
+            // O_CREAT|O_EXCL|O_DIRECT (or O_CREAT|O_TRUNC|O_DIRECT) creates the
+            // file *before* the FS rejects O_DIRECT with EINVAL, leaving an
+            // orphan on disk. Returning EINVAL here exercises the orphan-cleanup
+            // path in the callers.
+            let created = if truncate {
+                File::create(path).map(drop)
+            } else {
+                File::create_new(path).map(drop)
+            };
+            return match created {
+                Ok(()) => Err(io::Error::from_raw_os_error(libc::EINVAL)),
+                Err(e) => Err(e),
+            };
         }
-        Ok(Self::Buffered(BufWriter::with_capacity(
-            capacity,
-            File::create(path)?,
-        )))
+        Self::open_direct_write(path, capacity, truncate)
     }
 
     #[cfg(target_os = "linux")]
@@ -283,6 +319,29 @@ impl Read for ChunkedReader {
     }
 }
 
+/// Removes a file left behind by a failed direct-I/O open before the buffered
+/// fallback re-creates it.
+///
+/// On Linux, `O_CREAT|O_EXCL|O_DIRECT` (and `O_CREAT|O_TRUNC|O_DIRECT`) can
+/// create the file *before* the kernel rejects `O_DIRECT` with `EINVAL`, so the
+/// subsequent buffered `File::create_new` would otherwise fail with
+/// `AlreadyExists`. The path is freshly generated and unique to this writer, so
+/// removing it is safe. Best-effort: a missing file (the common case on
+/// filesystems that reject before creating) is ignored.
+fn remove_orphan_after_unsupported_open(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// Debug-only test hook: returns `true` when the
+/// `LSM_TREE_TEST_DIRECT_IO_FORCE_UNSUPPORTED` env var is set, forcing every
+/// direct-write open to simulate an `O_DIRECT`-rejecting filesystem. Lets the
+/// fallback path (and its orphan cleanup) be exercised deterministically on any
+/// filesystem. Never compiled into release builds.
+#[cfg(all(target_os = "linux", debug_assertions))]
+fn should_force_unsupported_open() -> bool {
+    std::env::var_os("LSM_TREE_TEST_DIRECT_IO_FORCE_UNSUPPORTED").is_some()
+}
+
 /// Emits a single `warn` per process when a filesystem rejects direct I/O.
 /// Subsequent fallbacks are silent so a tree on tmpfs doesn't flood logs.
 fn log_unsupported_once(path: &Path, e: &io::Error) {
@@ -404,6 +463,10 @@ mod tests {
         #[cfg(target_os = "linux")]
         {
             assert!(is_direct_io_unsupported(&einval));
+            // EOPNOTSUPP (== ENOTSUP on Linux) is also treated as "fall back".
+            assert!(is_direct_io_unsupported(&io::Error::from_raw_os_error(
+                libc::EOPNOTSUPP
+            )));
             assert!(!is_direct_io_unsupported(&other));
         }
         #[cfg(not(target_os = "linux"))]
@@ -411,6 +474,32 @@ mod tests {
             assert!(!is_direct_io_unsupported(&einval));
             assert!(!is_direct_io_unsupported(&other));
         }
+    }
+
+    /// Deterministically exercises the buffered fallback for a *new* table file
+    /// on a filesystem that rejects O_DIRECT, including the orphan left behind by
+    /// the kernel between file creation and the O_DIRECT rejection. Without the
+    /// orphan cleanup in `create_new_with_capacity`, the buffered
+    /// `File::create_new` would fail with `AlreadyExists`. Linux + debug only
+    /// (the fault-injection hook is compiled out of release builds).
+    #[cfg(all(target_os = "linux", debug_assertions))]
+    #[test]
+    fn create_new_falls_back_and_cleans_orphan_when_direct_io_rejected() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("orphan-fallback");
+
+        std::env::set_var("LSM_TREE_TEST_DIRECT_IO_FORCE_UNSUPPORTED", "1");
+        let result = ChunkedWriter::create_new(&path, true);
+        std::env::remove_var("LSM_TREE_TEST_DIRECT_IO_FORCE_UNSUPPORTED");
+
+        let mut w = result?;
+        w.write_all(b"fell back to buffered")?;
+        w.finalize()?.sync_all()?;
+
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut ChunkedReader::open(&path, false)?, &mut buf)?;
+        assert_eq!(buf, "fell back to buffered");
+        Ok(())
     }
 
     #[test]

--- a/src/direct_io/fallback.rs
+++ b/src/direct_io/fallback.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! Fallback for platforms with no direct-I/O primitive (e.g. WASI).
+//!
+//! All `open_*_direct` functions return a regular buffered file handle. The direct-I/O
+//! config knobs become silent no-ops. The `Config::open` callers do not need
+//! `cfg` guards.
+
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    path::Path,
+};
+
+pub fn open_read_direct(path: &Path) -> io::Result<File> {
+    File::open(path)
+}
+
+pub fn create_write_direct(path: &Path) -> io::Result<File> {
+    File::create_new(path)
+}
+
+pub fn create_or_truncate_write_direct(path: &Path) -> io::Result<File> {
+    OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+}

--- a/src/direct_io/linux.rs
+++ b/src/direct_io/linux.rs
@@ -1,0 +1,186 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! Linux-specific direct I/O: `O_DIRECT`.
+//!
+//! `O_DIRECT` is set at open time. The kernel rejects subsequent `read`/`write` calls
+//! whose user buffer pointer, file offset, and length are not all aligned to the
+//! underlying block device's logical block size (queryable at runtime).
+
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    os::unix::fs::OpenOptionsExt,
+    path::Path,
+    sync::OnceLock,
+};
+
+// The numeric value of `O_DIRECT` varies by architecture (x86 = 0x4000, aarch64 =
+// 0x10000, mips = 0x8000, powerpc = 0x20000, sparc = 0x100000, ...). `libc::O_DIRECT`
+// resolves to the correct per-target value at compile time.
+fn o_direct_flag() -> i32 {
+    libc::O_DIRECT
+}
+
+/// Opens an existing file for reading with `O_DIRECT` set.
+pub fn open_read_direct(path: &Path) -> io::Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(o_direct_flag())
+        .open(path)
+}
+
+/// Creates a new file for writing with `O_DIRECT` set. Fails if the file already exists,
+/// matching the existing `File::create_new` semantics used by table/blob writers.
+pub fn create_write_direct(path: &Path) -> io::Result<File> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .custom_flags(o_direct_flag())
+        .open(path)
+}
+
+/// Opens (or creates) a file for writing with `O_DIRECT` set, truncating if it exists.
+/// Used by blob file writers that call `File::create` rather than `create_new`.
+pub fn create_or_truncate_write_direct(path: &Path) -> io::Result<File> {
+    OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .custom_flags(o_direct_flag())
+        .open(path)
+}
+
+/// Reports the logical block size that the kernel will accept for `O_DIRECT` I/O.
+///
+/// We use the system page size as a conservative upper bound (the kernel accepts
+/// any power-of-two alignment at or above the device logical block size, and
+/// page size is at least 512 B on Linux). Querying the device's exact logical
+/// block size would require stat'ing the underlying block device, which is not
+/// worth the complexity.
+pub fn block_alignment() -> usize {
+    static CACHED: OnceLock<usize> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        // SAFETY: sysconf is async-signal-safe and takes a constant; no aliasing concerns.
+        #[expect(unsafe_code, reason = "libc FFI")]
+        let page_size = unsafe { libc_sysconf_pagesize() };
+
+        // Guard against a non-power-of-two return: `Layout::from_size_align` (used by
+        // `AlignedBuffer::new`) panics on non-power-of-two alignment, and every direct-I/O
+        // backend assumes alignment is a power of two. 4 KiB is the kernel-default page
+        // size on every modern Linux target.
+        let candidate = match usize::try_from(page_size) {
+            Ok(v) if v > 0 => v,
+            _ => 4_096,
+        };
+        if candidate >= 512 && candidate.is_power_of_two() {
+            candidate
+        } else {
+            log::warn!(
+                "sysconf(_SC_PAGESIZE) returned {candidate} which is not a power-of-two >= 512; falling back to 4 KiB",
+            );
+            4_096
+        }
+    })
+}
+
+/// Checks whether `O_DIRECT` is currently set on an opened file descriptor.
+///
+/// Used in tests to assert that the open path actually requested direct I/O.
+/// Linux is the only backend where this is observable post-open (`fcntl(F_GETFL)`
+/// returns the open flags); macOS has no equivalent query.
+#[cfg(test)]
+pub fn is_direct_io_enabled(file: &File) -> io::Result<bool> {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = file.as_raw_fd();
+    // SAFETY: fcntl(F_GETFL) on a valid fd is safe; the file is borrowed for the call.
+    #[expect(unsafe_code, reason = "libc FFI")]
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok((flags & o_direct_flag()) != 0)
+}
+
+/// Clears `O_DIRECT` from an open file descriptor.
+///
+/// Used after a non-EOF direct read returns an unaligned byte count: continuing
+/// with `O_DIRECT` would make the next implicit-offset read fail with `EINVAL`,
+/// while the buffered path can safely continue from that offset.
+pub fn disable_direct_io(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = file.as_raw_fd();
+    // SAFETY: fcntl(F_GETFL) on a valid fd is safe; the file is borrowed for the call.
+    #[expect(unsafe_code, reason = "libc FFI")]
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let new_flags = flags & !o_direct_flag();
+    if new_flags == flags {
+        return Ok(());
+    }
+
+    // SAFETY: fcntl(F_SETFL) updates status flags on a valid fd.
+    #[expect(unsafe_code, reason = "libc FFI")]
+    let rc = unsafe { libc::fcntl(fd, libc::F_SETFL, new_flags) };
+
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+// Thin wrapper around `sysconf(_SC_PAGESIZE)`. Returns `c_long` (the libc signature
+// — `i32` on 32-bit targets, `i64` on 64-bit). sysconf returns -1 on error.
+#[expect(unsafe_code, reason = "libc FFI")]
+unsafe fn libc_sysconf_pagesize() -> libc::c_long {
+    libc::sysconf(libc::_SC_PAGESIZE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use test_log::test;
+
+    #[test]
+    fn block_alignment_is_power_of_two_and_at_least_512() {
+        let a = block_alignment();
+        assert!(a >= 512);
+        assert!(a.is_power_of_two());
+    }
+
+    #[test]
+    fn open_read_direct_sets_o_direct() -> io::Result<()> {
+        // Some Linux filesystems (notably tmpfs) reject O_DIRECT. Skip on those.
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("probe");
+
+        // Write some data with a buffered handle first.
+        {
+            let mut f = std::fs::File::create(&path)?;
+            f.write_all(&vec![0u8; block_alignment()])?;
+            f.sync_all()?;
+        }
+
+        match open_read_direct(&path) {
+            Ok(direct) => {
+                assert!(is_direct_io_enabled(&direct)?);
+            }
+            Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
+                eprintln!("filesystem rejects O_DIRECT; skipping assertion");
+            }
+            Err(e) => return Err(e),
+        }
+        Ok(())
+    }
+}

--- a/src/direct_io/linux.rs
+++ b/src/direct_io/linux.rs
@@ -139,8 +139,8 @@ pub fn disable_direct_io(file: &File) -> io::Result<()> {
     Ok(())
 }
 
-// Thin wrapper around `sysconf(_SC_PAGESIZE)`. Returns `c_long` (the libc signature
-// — `i32` on 32-bit targets, `i64` on 64-bit). sysconf returns -1 on error.
+// Thin wrapper around `sysconf(_SC_PAGESIZE)`. Returns `c_long` (the libc
+// signature: `i32` on 32-bit targets, `i64` on 64-bit). Returns -1 on error.
 #[expect(unsafe_code, reason = "libc FFI")]
 unsafe fn libc_sysconf_pagesize() -> libc::c_long {
     libc::sysconf(libc::_SC_PAGESIZE)

--- a/src/direct_io/macos.rs
+++ b/src/direct_io/macos.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! macOS-specific direct I/O: `F_NOCACHE`.
+//!
+//! macOS does not have `O_DIRECT`. Instead, `F_NOCACHE` is applied to an open file
+//! descriptor via `fcntl`, instructing the kernel to bypass the unified buffer cache
+//! for subsequent reads/writes on that descriptor. Unlike `O_DIRECT`, `F_NOCACHE`
+//! imposes no alignment requirement on user buffers, file offsets, or I/O lengths.
+
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    os::unix::io::AsRawFd,
+    path::Path,
+};
+
+/// Opens an existing file for reading and enables `F_NOCACHE` on the descriptor.
+pub fn open_read_direct(path: &Path) -> io::Result<File> {
+    let file = File::open(path)?;
+    apply_no_cache(&file)?;
+    Ok(file)
+}
+
+/// Creates a new file for writing and enables `F_NOCACHE` on the descriptor.
+/// Fails if the file already exists, matching `File::create_new`.
+pub fn create_write_direct(path: &Path) -> io::Result<File> {
+    let file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    apply_no_cache(&file)?;
+    Ok(file)
+}
+
+/// Creates (or truncates) a file for writing and enables `F_NOCACHE` on the descriptor.
+pub fn create_or_truncate_write_direct(path: &Path) -> io::Result<File> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
+    apply_no_cache(&file)?;
+    Ok(file)
+}
+
+fn apply_no_cache(file: &File) -> io::Result<()> {
+    let fd = file.as_raw_fd();
+    // SAFETY: fcntl with F_NOCACHE on a valid fd is safe. We hold a reference to `file`
+    // for the duration of the call so the fd is guaranteed open.
+    #[expect(unsafe_code, reason = "libc FFI")]
+    let rc = unsafe { libc::fcntl(fd, libc::F_NOCACHE, 1) };
+
+    if rc < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    #[test]
+    fn open_read_direct_succeeds() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("probe");
+        std::fs::write(&path, b"hello world")?;
+        let _ = open_read_direct(&path)?;
+        Ok(())
+    }
+}

--- a/src/direct_io/macos.rs
+++ b/src/direct_io/macos.rs
@@ -14,12 +14,13 @@ use std::{
     io,
     os::unix::io::AsRawFd,
     path::Path,
+    sync::OnceLock,
 };
 
 /// Opens an existing file for reading and enables `F_NOCACHE` on the descriptor.
 pub fn open_read_direct(path: &Path) -> io::Result<File> {
     let file = File::open(path)?;
-    apply_no_cache(&file)?;
+    apply_no_cache(&file);
     Ok(file)
 }
 
@@ -27,7 +28,7 @@ pub fn open_read_direct(path: &Path) -> io::Result<File> {
 /// Fails if the file already exists, matching `File::create_new`.
 pub fn create_write_direct(path: &Path) -> io::Result<File> {
     let file = OpenOptions::new().write(true).create_new(true).open(path)?;
-    apply_no_cache(&file)?;
+    apply_no_cache(&file);
     Ok(file)
 }
 
@@ -38,11 +39,18 @@ pub fn create_or_truncate_write_direct(path: &Path) -> io::Result<File> {
         .create(true)
         .truncate(true)
         .open(path)?;
-    apply_no_cache(&file)?;
+    apply_no_cache(&file);
     Ok(file)
 }
 
-fn apply_no_cache(file: &File) -> io::Result<()> {
+/// Best-effort `F_NOCACHE` on the descriptor.
+///
+/// `F_NOCACHE` is an advisory cache hint: a descriptor without it is still fully
+/// correct, just cached (i.e. exactly the buffered fallback the module documents
+/// for filesystems that reject direct I/O). `fcntl(F_NOCACHE)` essentially never
+/// fails on a regular open fd, but if it does we keep the open file rather than
+/// hard-failing the flush/compaction, and warn once.
+fn apply_no_cache(file: &File) {
     let fd = file.as_raw_fd();
     // SAFETY: fcntl with F_NOCACHE on a valid fd is safe. We hold a reference to `file`
     // for the duration of the call so the fd is guaranteed open.
@@ -50,10 +58,19 @@ fn apply_no_cache(file: &File) -> io::Result<()> {
     let rc = unsafe { libc::fcntl(fd, libc::F_NOCACHE, 1) };
 
     if rc < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
+        log_f_nocache_unsupported_once(&io::Error::last_os_error());
     }
+}
+
+/// Warns a single time per process when `F_NOCACHE` could not be applied.
+fn log_f_nocache_unsupported_once(e: &io::Error) {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        log::warn!(
+            "F_NOCACHE not applied (first observed: {e}); proceeding with buffered I/O. \
+             The use_direct_io_for_* config flags will have no cache-bypass effect on this file.",
+        );
+    });
 }
 
 #[cfg(test)]

--- a/src/direct_io/macos.rs
+++ b/src/direct_io/macos.rs
@@ -45,11 +45,9 @@ pub fn create_or_truncate_write_direct(path: &Path) -> io::Result<File> {
 
 /// Best-effort `F_NOCACHE` on the descriptor.
 ///
-/// `F_NOCACHE` is an advisory cache hint: a descriptor without it is still fully
-/// correct, just cached (i.e. exactly the buffered fallback the module documents
-/// for filesystems that reject direct I/O). `fcntl(F_NOCACHE)` essentially never
-/// fails on a regular open fd, but if it does we keep the open file rather than
-/// hard-failing the flush/compaction, and warn once.
+/// `F_NOCACHE` is only a cache hint: without it the file is still correct, just
+/// cached. It rarely fails on an open fd, but if it does we keep the file and
+/// warn once rather than failing the flush/compaction.
 fn apply_no_cache(file: &File) {
     let fd = file.as_raw_fd();
     // SAFETY: fcntl with F_NOCACHE on a valid fd is safe. We hold a reference to `file`

--- a/src/direct_io/mod.rs
+++ b/src/direct_io/mod.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! Direct (unbuffered) I/O primitives for compaction and flush.
+//!
+//! Bypassing the OS page cache during compaction prevents the sequential, read-once
+//! scan from evicting hot user-read data. Per platform:
+//!
+//! - **Linux**: `O_DIRECT` at open time. Requires page-aligned user buffers, file
+//!   offsets, and lengths; alignment is queried via `sysconf(_SC_PAGESIZE)`.
+//! - **macOS**: `F_NOCACHE` applied via `fcntl` after open. No alignment requirement.
+//! - **Other** (including Windows): no-op; opens fall back to buffered I/O. The
+//!   `use_direct_io_for_*` config flags have no effect.
+
+// Aligned-buffer machinery is always compiled (its unit tests run on every
+// platform), but only wired into `ChunkedWriter`/`ChunkedReader` on Linux where
+// O_DIRECT requires alignment. Elsewhere the types are dead code
+// (`cfg_attr(... allow(dead_code))` below).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod aligned_buffer;
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod aligned_reader;
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod aligned_writer;
+mod chunked;
+
+/// Aligned-buffer capacity (in alignment units) for the read and write paths.
+///
+/// At 4 KiB alignment this is 64 KiB — the amortization sweet spot for
+/// compaction-grade sequential I/O.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub const BUFFER_BLOCKS: usize = 16;
+
+#[cfg(test)]
+mod syscall_assertions;
+
+#[cfg(target_os = "linux")]
+pub use aligned_reader::AlignedFileReader;
+#[cfg(target_os = "linux")]
+pub use aligned_writer::AlignedFileWriter;
+pub use chunked::{ChunkedReader, ChunkedWriter};
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+use linux as platform;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+use macos as platform;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod fallback;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+use fallback as platform;
+
+use std::{fs::File, io, path::Path};
+
+/// Opens an existing file for reading with direct I/O enabled.
+///
+/// On Linux, `O_DIRECT` is set atomically at open. On macOS, this opens the
+/// file and then applies `F_NOCACHE` to the descriptor. On other platforms,
+/// this is equivalent to `File::open`.
+pub fn open_read_direct(path: &Path) -> io::Result<File> {
+    platform::open_read_direct(path)
+}
+
+/// Creates a new file for writing with direct I/O enabled. Fails if the file exists.
+///
+/// Equivalent to `File::create_new` on unsupported platforms.
+pub fn create_write_direct(path: &Path) -> io::Result<File> {
+    platform::create_write_direct(path)
+}
+
+/// Creates or truncates a file for writing with direct I/O enabled.
+///
+/// Equivalent to `File::create` on unsupported platforms.
+pub fn create_or_truncate_write_direct(path: &Path) -> io::Result<File> {
+    platform::create_or_truncate_write_direct(path)
+}
+
+/// Returns the alignment to use for direct I/O. Linux only: `sysconf(_SC_PAGESIZE)`.
+/// Other platforms do not use the aligned-buffer path.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn block_alignment_for(_path: &Path) -> usize {
+    platform::block_alignment()
+}
+
+/// Test-only helper: returns whether `O_DIRECT` is set on an open fd.
+///
+/// Linux only: `fcntl(F_GETFL)` exposes the open flags. macOS (`F_NOCACHE`)
+/// has no equivalent post-open query.
+#[cfg(all(test, target_os = "linux"))]
+pub fn is_direct_io_enabled(file: &File) -> io::Result<bool> {
+    platform::is_direct_io_enabled(file)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    #[test]
+    fn block_alignment_for_returns_power_of_two_at_least_512() {
+        let a = block_alignment_for(std::path::Path::new("."));
+        assert!(a >= 512);
+        assert!(a.is_power_of_two());
+    }
+}

--- a/src/direct_io/mod.rs
+++ b/src/direct_io/mod.rs
@@ -101,6 +101,22 @@ pub fn block_alignment_for(_path: &Path) -> usize {
     platform::block_alignment()
 }
 
+/// Classifies a *runtime* read/write error on an `O_DIRECT` fd as "the
+/// filesystem/device doesn't actually support direct I/O at this alignment",
+/// in which case the aligned reader/writer drop `O_DIRECT` and continue
+/// buffered. Same errno set as the open-time classifier in `chunked`. Shared by
+/// `aligned_reader` and `aligned_writer`.
+#[cfg(target_os = "linux")]
+fn is_runtime_direct_io_unsupported(e: &io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(libc::EINVAL | libc::EOPNOTSUPP))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_runtime_direct_io_unsupported(_e: &io::Error) -> bool {
+    // The aligned reader/writer are only wired up on Linux; never hit elsewhere.
+    false
+}
+
 /// Test-only helper: returns whether `O_DIRECT` is set on an open fd.
 ///
 /// Linux only: `fcntl(F_GETFL)` exposes the open flags. macOS (`F_NOCACHE`)

--- a/src/direct_io/mod.rs
+++ b/src/direct_io/mod.rs
@@ -58,6 +58,14 @@ use fallback as platform;
 
 use std::{fs::File, io, path::Path};
 
+/// Test-only counter of direct-write opens (`create_write_direct` +
+/// `create_or_truncate_write_direct`). Lets tests assert that the flush /
+/// compaction *write* path actually requested direct I/O, not merely that the
+/// finished files can be re-opened with `O_DIRECT` for reading.
+#[cfg(test)]
+pub(crate) static DIRECT_WRITE_OPEN_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Opens an existing file for reading with direct I/O enabled.
 ///
 /// On Linux, `O_DIRECT` is set atomically at open. On macOS, this opens the
@@ -71,6 +79,8 @@ pub fn open_read_direct(path: &Path) -> io::Result<File> {
 ///
 /// Equivalent to `File::create_new` on unsupported platforms.
 pub fn create_write_direct(path: &Path) -> io::Result<File> {
+    #[cfg(test)]
+    DIRECT_WRITE_OPEN_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     platform::create_write_direct(path)
 }
 
@@ -78,6 +88,8 @@ pub fn create_write_direct(path: &Path) -> io::Result<File> {
 ///
 /// Equivalent to `File::create` on unsupported platforms.
 pub fn create_or_truncate_write_direct(path: &Path) -> io::Result<File> {
+    #[cfg(test)]
+    DIRECT_WRITE_OPEN_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     platform::create_or_truncate_write_direct(path)
 }
 

--- a/src/direct_io/mod.rs
+++ b/src/direct_io/mod.rs
@@ -25,10 +25,8 @@ mod aligned_reader;
 mod aligned_writer;
 mod chunked;
 
-/// Aligned-buffer capacity (in alignment units) for the read and write paths.
-///
-/// At 4 KiB alignment this is 64 KiB — the amortization sweet spot for
-/// compaction-grade sequential I/O.
+/// Aligned-buffer capacity, in alignment units, for the read and write paths.
+/// At 4 KiB alignment that's a 64 KiB buffer.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub const BUFFER_BLOCKS: usize = 16;
 
@@ -101,11 +99,9 @@ pub fn block_alignment_for(_path: &Path) -> usize {
     platform::block_alignment()
 }
 
-/// Classifies a *runtime* read/write error on an `O_DIRECT` fd as "the
-/// filesystem/device doesn't actually support direct I/O at this alignment",
-/// in which case the aligned reader/writer drop `O_DIRECT` and continue
-/// buffered. Same errno set as the open-time classifier in `chunked`. Shared by
-/// `aligned_reader` and `aligned_writer`.
+/// True if a read/write failed because the filesystem or device doesn't support
+/// `O_DIRECT` at this alignment. The aligned reader and writer use this to drop
+/// `O_DIRECT` and fall back to buffered. Same errnos as the open-time check.
 #[cfg(target_os = "linux")]
 fn is_runtime_direct_io_unsupported(e: &io::Error) -> bool {
     matches!(e.raw_os_error(), Some(libc::EINVAL | libc::EOPNOTSUPP))

--- a/src/direct_io/syscall_assertions.rs
+++ b/src/direct_io/syscall_assertions.rs
@@ -15,10 +15,14 @@ use test_log::test;
 
 /// Returns `true` if the error indicates the filesystem does not support direct I/O,
 /// in which case callers should skip the assertion (tmpfs/overlayfs/some FUSE FSes
-/// commonly reject `O_DIRECT` with `EINVAL`).
+/// reject `O_DIRECT` with `EINVAL`, some network/FUSE FSes with `EOPNOTSUPP`).
+///
+/// Matches the production classifier in `chunked::is_direct_io_unsupported` so the
+/// test skips exactly when production would fall back — never failing on a
+/// filesystem where production works.
 #[cfg(target_os = "linux")]
 fn is_unsupported(e: &std::io::Error) -> bool {
-    e.raw_os_error() == Some(libc::EINVAL)
+    matches!(e.raw_os_error(), Some(libc::EINVAL | libc::EOPNOTSUPP))
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -33,6 +37,9 @@ fn is_unsupported_classifier_recognises_einval_on_linux_only() {
     #[cfg(target_os = "linux")]
     {
         assert!(is_unsupported(&einval));
+        assert!(is_unsupported(&std::io::Error::from_raw_os_error(
+            libc::EOPNOTSUPP
+        )));
         assert!(!is_unsupported(&other));
     }
     #[cfg(not(target_os = "linux"))]

--- a/src/direct_io/syscall_assertions.rs
+++ b/src/direct_io/syscall_assertions.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! Platform-gated tests that verify the direct-I/O open path actually requested
+//! `O_DIRECT` (Linux). On other platforms the kernel exposes no per-fd query for
+//! the equivalent flag, so the syscall-level check is a "the open returned
+//! without error" probe only.
+
+#![cfg(test)]
+
+use super::{create_write_direct, open_read_direct};
+use std::io::Write;
+use test_log::test;
+
+/// Returns `true` if the error indicates the filesystem does not support direct I/O,
+/// in which case callers should skip the assertion (tmpfs/overlayfs/some FUSE FSes
+/// commonly reject `O_DIRECT` with `EINVAL`).
+#[cfg(target_os = "linux")]
+fn is_unsupported(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EINVAL)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_unsupported(_: &std::io::Error) -> bool {
+    false
+}
+
+#[test]
+fn is_unsupported_classifier_recognises_einval_on_linux_only() {
+    let einval = std::io::Error::from_raw_os_error(22);
+    let other = std::io::Error::other("not an OS error");
+    #[cfg(target_os = "linux")]
+    {
+        assert!(is_unsupported(&einval));
+        assert!(!is_unsupported(&other));
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert!(!is_unsupported(&einval));
+        assert!(!is_unsupported(&other));
+    }
+}
+
+#[test]
+fn create_write_direct_actually_sets_flag() -> std::io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("write");
+
+    match create_write_direct(&path) {
+        Ok(_file) => {
+            #[cfg(target_os = "linux")]
+            assert!(super::is_direct_io_enabled(&_file)?);
+        }
+        Err(e) if is_unsupported(&e) => {
+            eprintln!("filesystem rejects direct-write open; skipping: {e:?}");
+        }
+        Err(e) => return Err(e),
+    }
+    Ok(())
+}
+
+#[test]
+fn open_read_direct_actually_sets_flag() -> std::io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("read");
+
+    // Need real bytes so the read-direct probe doesn't trip on the empty-file
+    // alignment edge case.
+    {
+        let mut f = std::fs::File::create(&path)?;
+        f.write_all(&vec![0u8; 8_192])?;
+        f.sync_all()?;
+    }
+
+    match open_read_direct(&path) {
+        Ok(_file) => {
+            #[cfg(target_os = "linux")]
+            assert!(super::is_direct_io_enabled(&_file)?);
+        }
+        Err(e) if is_unsupported(&e) => {
+            eprintln!("filesystem rejects direct-read open; skipping: {e:?}");
+        }
+        Err(e) => return Err(e),
+    }
+    Ok(())
+}
+
+/// End-to-end: drive a tree flush + compaction with direct I/O enabled and snoop
+/// the syscall-level flag on every opened table file.
+///
+/// Only Linux can assert syscall-level — see module docs.
+#[test]
+fn integration_flush_and_compact_uses_direct_io_at_syscall_level() -> crate::Result<()> {
+    use crate::{direct_io, file::TABLES_FOLDER, AbstractTree, Config, SequenceNumberCounter};
+
+    let folder = tempfile::tempdir()?;
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(
+        folder.path(),
+        seqno.clone(),
+        SequenceNumberCounter::default(),
+    )
+    .use_direct_io_for_flush_and_compaction(true)
+    .use_direct_io_for_compaction_reads(true)
+    .open()?;
+
+    // Pre-flight: confirm the test directory's filesystem supports direct reads.
+    // tmpfs / overlayfs / some FUSE filesystems reject O_DIRECT with EINVAL.
+    let probe_path = folder.path().join(".direct_io_probe");
+    {
+        let mut probe = std::fs::File::create(&probe_path)?;
+        probe.write_all(&vec![0u8; 8_192])?;
+        probe.sync_all()?;
+    }
+    let supported = match direct_io::open_read_direct(&probe_path) {
+        Ok(_) => true,
+        Err(e) if is_unsupported(&e) => false,
+        Err(e) => return Err(e.into()),
+    };
+    let _ = std::fs::remove_file(&probe_path);
+    if !supported {
+        eprintln!("filesystem does not support direct I/O; skipping integration assertion");
+        return Ok(());
+    }
+
+    for i in 0..1_000 {
+        tree.insert(format!("k{i:08}").as_bytes(), b"payload", seqno.next());
+    }
+    tree.flush_active_memtable(0)?;
+
+    // On Linux, fcntl(F_GETFL) can read back the O_DIRECT flag on a freshly opened
+    // file. Elsewhere the flag is unobservable post-open, so we only check that
+    // the open succeeded.
+    let tables_folder = folder.path().join(TABLES_FOLDER);
+    for entry in std::fs::read_dir(&tables_folder)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let _file = direct_io::open_read_direct(&entry.path())?;
+        #[cfg(target_os = "linux")]
+        assert!(direct_io::is_direct_io_enabled(&_file)?);
+    }
+
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+
+    for entry in std::fs::read_dir(&tables_folder)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let _file = direct_io::open_read_direct(&entry.path())?;
+        #[cfg(target_os = "linux")]
+        assert!(direct_io::is_direct_io_enabled(&_file)?);
+    }
+
+    Ok(())
+}

--- a/src/direct_io/syscall_assertions.rs
+++ b/src/direct_io/syscall_assertions.rs
@@ -124,10 +124,26 @@ fn integration_flush_and_compact_uses_direct_io_at_syscall_level() -> crate::Res
         return Ok(());
     }
 
+    use std::sync::atomic::Ordering;
+
+    // Two flushes of the *same* key range produce two overlapping tables, so the
+    // subsequent major compaction must rewrite a merged output (it cannot be a
+    // trivial manifest-only move) — guaranteeing the compaction-output write path
+    // is exercised.
     for i in 0..1_000 {
-        tree.insert(format!("k{i:08}").as_bytes(), b"payload", seqno.next());
+        tree.insert(format!("k{i:08}").as_bytes(), b"payload-v1", seqno.next());
     }
+
+    // Prove the *write* path itself requested direct I/O — not just that the
+    // finished files happen to be re-openable with O_DIRECT below. Without this,
+    // the read-back assertions would still pass even if flush/compaction silently
+    // stopped routing writes through the direct-I/O writer.
+    direct_io::DIRECT_WRITE_OPEN_COUNT.store(0, Ordering::Relaxed);
     tree.flush_active_memtable(0)?;
+    assert!(
+        direct_io::DIRECT_WRITE_OPEN_COUNT.load(Ordering::Relaxed) > 0,
+        "flush did not open any file through the direct-write path",
+    );
 
     // On Linux, fcntl(F_GETFL) can read back the O_DIRECT flag on a freshly opened
     // file. Elsewhere the flag is unobservable post-open, so we only check that
@@ -143,7 +159,18 @@ fn integration_flush_and_compact_uses_direct_io_at_syscall_level() -> crate::Res
         assert!(direct_io::is_direct_io_enabled(&_file)?);
     }
 
+    // Second overlapping table so the compaction below has something to merge.
+    for i in 0..1_000 {
+        tree.insert(format!("k{i:08}").as_bytes(), b"payload-v2", seqno.next());
+    }
+    tree.flush_active_memtable(0)?;
+
+    direct_io::DIRECT_WRITE_OPEN_COUNT.store(0, Ordering::Relaxed);
     tree.major_compact(64 * 1_024 * 1_024, 0)?;
+    assert!(
+        direct_io::DIRECT_WRITE_OPEN_COUNT.load(Ordering::Relaxed) > 0,
+        "compaction did not open any output file through the direct-write path",
+    );
 
     for entry in std::fs::read_dir(&tables_folder)? {
         let entry = entry?;

--- a/src/direct_io/syscall_assertions.rs
+++ b/src/direct_io/syscall_assertions.rs
@@ -17,8 +17,8 @@ use test_log::test;
 /// in which case callers should skip the assertion (tmpfs/overlayfs/some FUSE FSes
 /// reject `O_DIRECT` with `EINVAL`, some network/FUSE FSes with `EOPNOTSUPP`).
 ///
-/// Matches the production classifier in `chunked::is_direct_io_unsupported` so the
-/// test skips exactly when production would fall back — never failing on a
+/// Matches the production classifier in `chunked::is_direct_io_unsupported`, so the
+/// test skips exactly when production would fall back and never fails on a
 /// filesystem where production works.
 #[cfg(target_os = "linux")]
 fn is_unsupported(e: &std::io::Error) -> bool {
@@ -96,7 +96,7 @@ fn open_read_direct_actually_sets_flag() -> std::io::Result<()> {
 /// End-to-end: drive a tree flush + compaction with direct I/O enabled and snoop
 /// the syscall-level flag on every opened table file.
 ///
-/// Only Linux can assert syscall-level — see module docs.
+/// Only Linux can assert at the syscall level; see module docs.
 #[test]
 fn integration_flush_and_compact_uses_direct_io_at_syscall_level() -> crate::Result<()> {
     use crate::{direct_io, file::TABLES_FOLDER, AbstractTree, Config, SequenceNumberCounter};
@@ -134,14 +134,13 @@ fn integration_flush_and_compact_uses_direct_io_at_syscall_level() -> crate::Res
     use std::sync::atomic::Ordering;
 
     // Two flushes of the *same* key range produce two overlapping tables, so the
-    // subsequent major compaction must rewrite a merged output (it cannot be a
-    // trivial manifest-only move) — guaranteeing the compaction-output write path
-    // is exercised.
+    // major compaction below must rewrite a merged output (it can't be a trivial
+    // manifest-only move). That guarantees the compaction-output write path runs.
     for i in 0..1_000 {
         tree.insert(format!("k{i:08}").as_bytes(), b"payload-v1", seqno.next());
     }
 
-    // Prove the *write* path itself requested direct I/O — not just that the
+    // Prove the *write* path itself requested direct I/O, not just that the
     // finished files happen to be re-openable with O_DIRECT below. Without this,
     // the read-back assertions would still pass even if flush/compaction silently
     // stopped routing writes through the direct-I/O writer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,10 @@ pub mod config;
 #[doc(hidden)]
 pub mod descriptor_table;
 
+// `direct_io` is an internal implementation detail; the public surface for the
+// feature is the two `use_direct_io_for_*` builder methods on `Config`.
+pub(crate) mod direct_io;
+
 #[doc(hidden)]
 pub mod file_accessor;
 

--- a/src/run_scanner.rs
+++ b/src/run_scanner.rs
@@ -13,12 +13,19 @@ pub struct RunScanner {
     lo: usize,
     hi: usize,
     lo_reader: Option<Scanner>,
+    /// Propagated to each per-table `Scanner` so the I/O mode is consistent across
+    /// the run.
+    use_direct_io: bool,
 }
 
 impl RunScanner {
+    /// Constructs a `RunScanner` over the given range. When `use_direct_io` is
+    /// `true` each per-table scanner opens the underlying file with platform
+    /// direct I/O.
     pub fn culled(
         run: Arc<Run<Table>>,
         (lo, hi): (Option<usize>, Option<usize>),
+        use_direct_io: bool,
     ) -> crate::Result<Self> {
         let lo = lo.unwrap_or_default();
         let hi = hi.unwrap_or(run.len() - 1);
@@ -29,13 +36,14 @@ impl RunScanner {
         )]
         let lo_table = run.get(lo).expect("should exist");
 
-        let lo_reader = lo_table.scan()?;
+        let lo_reader = lo_table.scan(use_direct_io)?;
 
         Ok(Self {
             tables: run,
             lo,
             hi,
             lo_reader: Some(lo_reader),
+            use_direct_io,
         })
     }
 }
@@ -59,8 +67,11 @@ impl Iterator for RunScanner {
                         clippy::expect_used,
                         reason = "hi is at most equal to the last slot; so because 0 <= lo <= hi, it must be a valid index"
                     )]
-                    let scanner =
-                        fail_iter!(self.tables.get(self.lo).expect("should exist").scan());
+                    let scanner = fail_iter!(self
+                        .tables
+                        .get(self.lo)
+                        .expect("should exist")
+                        .scan(self.use_direct_io));
 
                     self.lo_reader = Some(scanner);
                 }
@@ -112,7 +123,7 @@ mod tests {
 
         #[expect(clippy::unwrap_used)]
         {
-            let multi_reader = RunScanner::culled(level.clone(), (None, None))?;
+            let multi_reader = RunScanner::culled(level.clone(), (None, None), false)?;
 
             let mut iter = multi_reader.flatten();
 
@@ -133,7 +144,7 @@ mod tests {
 
         #[expect(clippy::unwrap_used)]
         {
-            let multi_reader = RunScanner::culled(level, (Some(1), None))?;
+            let multi_reader = RunScanner::culled(level, (Some(1), None), false)?;
 
             let mut iter = multi_reader.flatten();
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -350,8 +350,12 @@ impl Table {
     /// # Errors
     ///
     /// Will return `Err` if an IO error occurs.
+    /// When `use_direct_io` is `true` the underlying file is opened with platform
+    /// direct I/O, bypassing the OS page cache for the entire scan — what
+    /// compaction wants when [`crate::Config::use_direct_io_for_compaction_reads`]
+    /// is on.
     #[doc(hidden)]
-    pub fn scan(&self) -> crate::Result<Scanner> {
+    pub fn scan(&self, use_direct_io: bool) -> crate::Result<Scanner> {
         #[expect(
             clippy::expect_used,
             reason = "there shouldn't be 4 billion data blocks in a single table"
@@ -367,6 +371,7 @@ impl Table {
             block_count,
             self.metadata.data_block_compression,
             self.global_seqno(),
+            use_direct_io,
         )
     }
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -351,7 +351,7 @@ impl Table {
     ///
     /// Will return `Err` if an IO error occurs.
     /// When `use_direct_io` is `true` the underlying file is opened with platform
-    /// direct I/O, bypassing the OS page cache for the entire scan — what
+    /// direct I/O, bypassing the OS page cache for the whole scan, which is what
     /// compaction wants when [`crate::Config::use_direct_io_for_compaction_reads`]
     /// is on.
     #[doc(hidden)]

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -25,6 +25,10 @@ pub struct MultiWriter {
     use_partitioned_index: bool,
     use_partitioned_filter: bool,
 
+    /// When `true`, the per-table `Writer` is constructed with direct I/O enabled.
+    /// Propagated from `Config::use_direct_io_for_flush_and_compaction`.
+    use_direct_io: bool,
+
     /// Target size of tables in bytes
     ///
     /// If a table reaches the target size, a new one is started,
@@ -51,17 +55,20 @@ pub struct MultiWriter {
 }
 
 impl MultiWriter {
-    /// Sets up a new `MultiWriter` at the given tables folder
+    /// Sets up a new `MultiWriter` at the given tables folder. When
+    /// `use_direct_io` is `true` each underlying table file is opened with
+    /// platform direct I/O.
     pub fn new(
         base_path: PathBuf,
         table_id_generator: SequenceNumberCounter,
         target_size: u64,
         initial_level: u8,
+        use_direct_io: bool,
     ) -> crate::Result<Self> {
         let current_table_id = table_id_generator.next();
 
         let path = base_path.join(current_table_id.to_string());
-        let writer = Writer::new(path, current_table_id, initial_level)?;
+        let writer = Writer::new(path, current_table_id, initial_level, use_direct_io)?;
 
         Ok(Self {
             initial_level,
@@ -85,6 +92,8 @@ impl MultiWriter {
 
             use_partitioned_index: false,
             use_partitioned_filter: false,
+
+            use_direct_io,
 
             bloom_policy: BloomConstructionPolicy::default(),
 
@@ -184,14 +193,17 @@ impl MultiWriter {
         let new_table_id = self.table_id_generator.next();
         let path = self.base_path.join(new_table_id.to_string());
 
-        let mut new_writer = Writer::new(path, new_table_id, self.initial_level)?
-            .use_data_block_compression(self.data_block_compression)
-            .use_index_block_compression(self.index_block_compression)
-            .use_data_block_size(self.data_block_size)
-            .use_data_block_restart_interval(self.data_block_restart_interval)
-            .use_index_block_restart_interval(self.index_block_restart_interval)
-            .use_bloom_policy(self.bloom_policy)
-            .use_data_block_hash_ratio(self.data_block_hash_ratio);
+        // Rotation must preserve the direct-I/O setting so every table in a run is
+        // written through the same I/O path.
+        let mut new_writer =
+            Writer::new(path, new_table_id, self.initial_level, self.use_direct_io)?
+                .use_data_block_compression(self.data_block_compression)
+                .use_index_block_compression(self.index_block_compression)
+                .use_data_block_size(self.data_block_size)
+                .use_data_block_restart_interval(self.data_block_restart_interval)
+                .use_index_block_restart_interval(self.index_block_restart_interval)
+                .use_bloom_policy(self.bloom_policy)
+                .use_data_block_hash_ratio(self.data_block_hash_ratio);
 
         if self.use_partitioned_index {
             new_writer = new_writer.use_partitioned_index();

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -4,14 +4,15 @@
 
 use super::{Block, DataBlock};
 use crate::{
+    direct_io::ChunkedReader,
     table::{block::BlockType, iter::OwnedDataBlockIter},
     CompressionType, InternalValue, SeqNo,
 };
-use std::{fs::File, io::BufReader, path::Path};
+use std::path::Path;
 
 /// Table reader that is optimized for consuming an entire table
 pub struct Scanner {
-    reader: BufReader<File>,
+    reader: ChunkedReader,
     iter: OwnedDataBlockIter,
 
     compression: CompressionType,
@@ -22,15 +23,17 @@ pub struct Scanner {
 }
 
 impl Scanner {
+    /// Opens a table file for sequential scanning. When `use_direct_io` is
+    /// `true` the underlying file is opened with platform direct I/O; the
+    /// compaction worker passes [`crate::Config::use_direct_io_for_compaction_reads`].
     pub fn new(
         path: &Path,
         block_count: usize,
         compression: CompressionType,
         global_seqno: SeqNo,
+        use_direct_io: bool,
     ) -> crate::Result<Self> {
-        // TODO: a larger buffer size may be better for HDD, maybe make this configurable
-        // TODO: benchmarks were inconclusive on SSD, not much difference between 4KB - 2MB
-        let mut reader = BufReader::with_capacity(8 * 4_096, File::open(path)?);
+        let mut reader = ChunkedReader::open(path, use_direct_io)?;
 
         let block = Self::fetch_next_block(&mut reader, compression)?;
         let iter = OwnedDataBlockIter::new(block, DataBlock::iter);
@@ -48,7 +51,7 @@ impl Scanner {
     }
 
     fn fetch_next_block(
-        reader: &mut BufReader<File>,
+        reader: &mut ChunkedReader,
         compression: CompressionType,
     ) -> crate::Result<DataBlock> {
         let block = Block::from_reader(reader, compression);

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -25,7 +25,7 @@ fn test_with_table(
     let file = dir.path().join("table");
 
     {
-        let mut writer = Writer::new(file.clone(), 0, 0)?;
+        let mut writer = Writer::new(file.clone(), 0, 0, false)?;
 
         if let Some(f) = &config_writer {
             writer = f(writer);
@@ -193,7 +193,7 @@ fn test_with_table(
 
     // Test with partitioned indexes
     {
-        let mut writer = Writer::new(file.clone(), 0, 0)?.use_partitioned_index();
+        let mut writer = Writer::new(file.clone(), 0, 0, false)?.use_partitioned_index();
 
         if let Some(f) = config_writer {
             writer = f(writer);
@@ -517,7 +517,7 @@ fn table_scan() -> crate::Result<()> {
     test_with_table(
         &items,
         |table| {
-            assert_eq!(items, &*table.scan()?.flatten().collect::<Vec<_>>());
+            assert_eq!(items, &*table.scan(false)?.flatten().collect::<Vec<_>>());
 
             assert_eq!(
                 table.metadata.key_range,
@@ -1206,7 +1206,7 @@ fn table_read_fuzz_1() -> crate::Result<()> {
 
     let data_block_size = 97;
 
-    let mut writer = crate::table::Writer::new(file.clone(), 0, 0)
+    let mut writer = crate::table::Writer::new(file.clone(), 0, 0, false)
         .unwrap()
         .use_data_block_size(data_block_size);
 
@@ -1278,7 +1278,7 @@ fn table_partitioned_index() -> crate::Result<()> {
     let dir = tempfile::tempdir()?;
     let file = dir.path().join("table_fuzz");
 
-    let mut writer = crate::table::Writer::new(file.clone(), 0, 0)
+    let mut writer = crate::table::Writer::new(file.clone(), 0, 0, false)
         .unwrap()
         .use_partitioned_index()
         .use_data_block_size(5)
@@ -1388,7 +1388,7 @@ fn table_global_seqno() -> crate::Result<()> {
     let dir = tempfile::tempdir()?;
     let file = dir.path().join("table_fuzz");
 
-    let mut writer = crate::table::Writer::new(file.clone(), 0, 0)?
+    let mut writer = crate::table::Writer::new(file.clone(), 0, 0, false)?
         .use_partitioned_filter()
         .use_data_block_size(1)
         .use_meta_partition_size(1);
@@ -1440,7 +1440,7 @@ fn table_return_global_seqno() -> crate::Result<()> {
     let dir = tempfile::tempdir()?;
     let file = dir.path().join("table_fuzz");
 
-    let mut writer = crate::table::Writer::new(file.clone(), 0, 0)?;
+    let mut writer = crate::table::Writer::new(file.clone(), 0, 0, false)?;
 
     for item in items {
         writer.write(item)?;

--- a/src/table/writer/filter/full.rs
+++ b/src/table/writer/filter/full.rs
@@ -6,10 +6,10 @@ use super::FilterWriter;
 use crate::{
     checksum::ChecksummedWriter,
     config::BloomConstructionPolicy,
+    direct_io::ChunkedWriter,
     table::{filter::standard_bloom::Builder, Block},
     CompressionType, UserKey,
 };
-use std::{fs::File, io::BufWriter};
 
 pub struct FullFilterWriter {
     /// Key hashes for AMQ filter
@@ -51,7 +51,7 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for FullFilterWriter {
 
     fn finish(
         self: Box<Self>,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
     ) -> crate::Result<usize> {
         if self.bloom_hash_buffer.is_empty() {
             log::trace!("Filter writer has no buffered hashes - not building filter");

--- a/src/table/writer/filter/mod.rs
+++ b/src/table/writer/filter/mod.rs
@@ -9,9 +9,9 @@ pub use full::FullFilterWriter;
 pub use partitioned::PartitionedFilterWriter;
 
 use crate::{
-    checksum::ChecksummedWriter, config::BloomConstructionPolicy, CompressionType, UserKey,
+    checksum::ChecksummedWriter, config::BloomConstructionPolicy, direct_io::ChunkedWriter,
+    CompressionType, UserKey,
 };
-use std::{fs::File, io::BufWriter};
 
 pub trait FilterWriter<W: std::io::Write> {
     // NOTE: We purposefully use a UserKey instead of &[u8]
@@ -24,7 +24,7 @@ pub trait FilterWriter<W: std::io::Write> {
     /// Returns the number of filter blocks written (always 1 in case of full filter block).
     fn finish(
         self: Box<Self>,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
     ) -> crate::Result<usize>;
 
     fn set_filter_policy(

--- a/src/table/writer/filter/partitioned.rs
+++ b/src/table/writer/filter/partitioned.rs
@@ -6,16 +6,14 @@ use super::FilterWriter;
 use crate::{
     checksum::ChecksummedWriter,
     config::BloomConstructionPolicy,
+    direct_io::ChunkedWriter,
     table::{
         block::Header as BlockHeader, filter::standard_bloom::Builder, Block, BlockHandle,
         BlockOffset, IndexBlock, KeyedBlockHandle,
     },
     CompressionType, UserKey,
 };
-use std::{
-    fs::File,
-    io::{BufWriter, Seek, Write},
-};
+use std::io::{Seek, Write};
 
 pub struct PartitionedFilterWriter {
     final_filter_buffer: Vec<u8>,
@@ -102,7 +100,7 @@ impl PartitionedFilterWriter {
 
     fn write_top_level_index(
         &mut self,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
         index_base_offset: BlockOffset,
     ) -> crate::Result<()> {
         file_writer.start("filter_tli")?;
@@ -178,7 +176,7 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for PartitionedFilterWri
 
     fn finish(
         mut self: Box<Self>,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
     ) -> crate::Result<usize> {
         if self.last_key.is_none() {
             log::trace!("Filter writer has not seen any writes - not building filter");

--- a/src/table/writer/index/full.rs
+++ b/src/table/writer/index/full.rs
@@ -4,13 +4,13 @@
 
 use crate::{
     checksum::ChecksummedWriter,
+    direct_io::ChunkedWriter,
     table::{
         block::Header as BlockHeader, index_block::KeyedBlockHandle,
         writer::index::BlockIndexWriter, Block, IndexBlock,
     },
     CompressionType,
 };
-use std::{fs::File, io::BufWriter};
 
 pub struct FullIndexWriter {
     compression: CompressionType,
@@ -54,7 +54,7 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter 
 
     fn finish(
         self: Box<Self>,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
     ) -> crate::Result<usize> {
         file_writer.start("tli")?;
 

--- a/src/table/writer/index/mod.rs
+++ b/src/table/writer/index/mod.rs
@@ -8,8 +8,10 @@ mod partitioned;
 pub use full::FullIndexWriter;
 pub use partitioned::PartitionedIndexWriter;
 
-use crate::{checksum::ChecksummedWriter, table::index_block::KeyedBlockHandle, CompressionType};
-use std::{fs::File, io::BufWriter};
+use crate::{
+    checksum::ChecksummedWriter, direct_io::ChunkedWriter, table::index_block::KeyedBlockHandle,
+    CompressionType,
+};
 
 pub trait BlockIndexWriter<W: std::io::Write> {
     /// Registers a data block in the block index.
@@ -20,7 +22,7 @@ pub trait BlockIndexWriter<W: std::io::Write> {
     /// Returns the number of index blocks written.
     fn finish(
         self: Box<Self>,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
     ) -> crate::Result<usize>;
 
     fn use_compression(

--- a/src/table/writer/index/partitioned.rs
+++ b/src/table/writer/index/partitioned.rs
@@ -4,16 +4,14 @@
 
 use crate::{
     checksum::ChecksummedWriter,
+    direct_io::ChunkedWriter,
     table::{
         block::Header as BlockHeader, index_block::KeyedBlockHandle,
         writer::index::BlockIndexWriter, Block, BlockHandle, BlockOffset, IndexBlock,
     },
     CompressionType,
 };
-use std::{
-    fs::File,
-    io::{BufWriter, Seek, Write},
-};
+use std::io::{Seek, Write};
 
 pub struct PartitionedIndexWriter {
     relative_file_pos: u64,
@@ -105,7 +103,7 @@ impl PartitionedIndexWriter {
 
     fn write_top_level_index(
         &mut self,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
         index_base_offset: BlockOffset,
     ) -> crate::Result<()> {
         file_writer.start("tli")?;
@@ -183,7 +181,7 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for PartitionedIndex
 
     fn finish(
         mut self: Box<Self>,
-        file_writer: &mut sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+        file_writer: &mut sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
     ) -> crate::Result<usize> {
         if self.buffer_size > 0 {
             self.cut_index_block()?;

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -382,11 +382,11 @@ impl Writer {
 
         self.spill_block()?;
 
-        // No items written! Just delete table file and return nothing.
-        // Drop the file_writer first via `cancel` so the AlignedFileWriter (if any)
-        // does not try to write a padded trailing block / set_len on a file we are
-        // about to remove (which would be wasted I/O on Unix and can fail with
-        // ERROR_ACCESS_DENIED on Windows when the file is already marked-for-deletion).
+        // No items written! Just delete the table file and return nothing.
+        // Release the file via `cancel` (not `finalize`) so the AlignedFileWriter
+        // (if any) does not write its trailing tail to a file we're about to
+        // remove. Wasted I/O on Unix; can fail on Windows with ERROR_ACCESS_DENIED
+        // when the file is already marked for deletion.
         if self.meta.item_count == 0 {
             let checksum_writer = self.file_writer.into_inner()?;
             let (chunked, _) = checksum_writer.into_inner();
@@ -530,13 +530,12 @@ impl Writer {
             )?;
         };
 
-        // Write fixed-size trailer
-        // and flush & fsync the table file.
+        // Write fixed-size trailer, then flush & fsync the table file.
         //
-        // For direct-I/O writes, ChunkedWriter::finalize drains the buffered tail —
-        // emitting full aligned chunks through the O_DIRECT handle and the final
-        // sub-alignment tail through a separate buffered handle — so the file ends
-        // at exactly the real byte count (no zero padding persisted). We then fsync.
+        // For direct-I/O writes, ChunkedWriter::finalize drains the buffered tail:
+        // full aligned chunks go through the O_DIRECT handle and the final
+        // sub-alignment tail through a separate buffered handle, so the file ends at
+        // exactly the real byte count (no zero padding persisted). We then fsync.
         let checksum_writer = self.file_writer.into_inner()?;
         let (chunked, checksum) = checksum_writer.into_inner();
         let file = chunked.finalize()?;

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::{
     checksum::{ChecksumType, ChecksummedWriter},
     coding::Encode,
+    direct_io::ChunkedWriter,
     file::fsync_directory,
     table::{
         writer::{
@@ -26,7 +27,7 @@ use crate::{
     Checksum, CompressionType, InternalValue, TableId, UserKey, ValueType,
 };
 use index::BlockIndexWriter;
-use std::{fs::File, io::BufWriter, path::PathBuf};
+use std::path::PathBuf;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, std::hash::Hash)]
 pub struct LinkedFile {
@@ -63,15 +64,15 @@ pub struct Writer {
 
     /// File writer
     #[expect(clippy::struct_field_names)]
-    file_writer: sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+    file_writer: sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
 
     /// Writer of index blocks
     #[expect(clippy::struct_field_names)]
-    index_writer: Box<dyn BlockIndexWriter<BufWriter<File>>>,
+    index_writer: Box<dyn BlockIndexWriter<ChunkedWriter>>,
 
     /// Writer of filter
     #[expect(clippy::struct_field_names)]
-    filter_writer: Box<dyn FilterWriter<BufWriter<File>>>,
+    filter_writer: Box<dyn FilterWriter<ChunkedWriter>>,
 
     /// Buffer of KVs
     chunk: Vec<InternalValue>,
@@ -95,8 +96,16 @@ pub struct Writer {
 }
 
 impl Writer {
-    pub fn new(path: PathBuf, table_id: TableId, initial_level: u8) -> crate::Result<Self> {
-        let writer = BufWriter::with_capacity(u16::MAX.into(), File::create_new(&path)?);
+    /// Opens a new table file for writing. When `use_direct_io` is `true` the
+    /// underlying file is opened with platform direct I/O; flush and compaction
+    /// paths pass [`crate::Config::use_direct_io_for_flush_and_compaction`].
+    pub fn new(
+        path: PathBuf,
+        table_id: TableId,
+        initial_level: u8,
+        use_direct_io: bool,
+    ) -> crate::Result<Self> {
+        let writer = ChunkedWriter::create_new(&path, use_direct_io)?;
         let writer = ChecksummedWriter::new(writer);
         let mut writer = sfa::Writer::from_writer(writer);
         writer.start("data")?;
@@ -373,8 +382,16 @@ impl Writer {
 
         self.spill_block()?;
 
-        // No items written! Just delete table file and return nothing
+        // No items written! Just delete table file and return nothing.
+        // Drop the file_writer first via `cancel` so the AlignedFileWriter (if any)
+        // does not try to write a padded trailing block / set_len on a file we are
+        // about to remove (which would be wasted I/O on Unix and can fail with
+        // ERROR_ACCESS_DENIED on Windows when the file is already marked-for-deletion).
         if self.meta.item_count == 0 {
+            let checksum_writer = self.file_writer.into_inner()?;
+            let (chunked, _) = checksum_writer.into_inner();
+            let file = chunked.cancel();
+            drop(file);
             std::fs::remove_file(&self.path)?;
             return Ok(None);
         }
@@ -514,10 +531,15 @@ impl Writer {
         };
 
         // Write fixed-size trailer
-        // and flush & fsync the table file
-        let mut checksum = self.file_writer.into_inner()?;
-        checksum.inner_mut().get_mut().sync_all()?;
-        let checksum = checksum.checksum();
+        // and flush & fsync the table file.
+        //
+        // For direct-I/O writes, ChunkedWriter::finalize zero-pads the trailing block
+        // (which the kernel requires) and then truncates the file back to the real
+        // byte count before we sync.
+        let checksum_writer = self.file_writer.into_inner()?;
+        let (chunked, checksum) = checksum_writer.into_inner();
+        let file = chunked.finalize()?;
+        file.sync_all()?;
 
         // IMPORTANT: fsync folder on Unix
 
@@ -548,7 +570,7 @@ mod tests {
     fn table_writer_count() -> crate::Result<()> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("1");
-        let mut writer = Writer::new(path, 1, 0)?;
+        let mut writer = Writer::new(path, 1, 0, false)?;
 
         assert_eq!(0, writer.meta.key_count);
         assert_eq!(0, writer.chunk_size);

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -533,9 +533,10 @@ impl Writer {
         // Write fixed-size trailer
         // and flush & fsync the table file.
         //
-        // For direct-I/O writes, ChunkedWriter::finalize zero-pads the trailing block
-        // (which the kernel requires) and then truncates the file back to the real
-        // byte count before we sync.
+        // For direct-I/O writes, ChunkedWriter::finalize drains the buffered tail —
+        // emitting full aligned chunks through the O_DIRECT handle and the final
+        // sub-alignment tail through a separate buffered handle — so the file ends
+        // at exactly the real byte count (no zero padding persisted). We then fsync.
         let checksum_writer = self.file_writer.into_inner()?;
         let (chunked, checksum) = checksum_writer.into_inner();
         let file = chunked.finalize()?;

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -46,11 +46,14 @@ impl<'a> Ingestion<'a> {
             .get(INITIAL_CANONICAL_LEVEL);
 
         // TODO: maybe create a PrepareMultiWriter that can be used by flush, ingest and compaction worker
+        // Ingest is write-once just like flush and compaction-output, so it honors the
+        // same direct-I/O knob (`use_direct_io_for_flush_and_compaction`).
         let mut writer = MultiWriter::new(
             folder.clone(),
             tree.table_id_counter.clone(),
             64 * 1_024 * 1_024,
             6,
+            tree.config.use_direct_io_for_flush_and_compaction,
         )?
         .use_bloom_policy({
             if tree.config.expect_point_read_hits {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -373,6 +373,7 @@ impl AbstractTree for Tree {
             self.table_id_counter.clone(),
             64 * 1_024 * 1_024,
             0,
+            self.config.use_direct_io_for_flush_and_compaction,
         )?
         .use_data_block_restart_interval(data_block_restart_interval)
         .use_index_block_restart_interval(index_block_restart_interval)

--- a/src/vlog/blob_file/merge.rs
+++ b/src/vlog/blob_file/merge.rs
@@ -109,7 +109,7 @@ mod tests {
         let blob_file_path = dir.path().join("0");
         {
             {
-                let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0)?;
+                let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0, false)?;
 
                 writer.write(b"a", 1, &b"1".repeat(100))?;
                 writer.write(b"a", 0, &b"0".repeat(100))?;
@@ -119,7 +119,7 @@ mod tests {
         }
 
         {
-            let mut merger = MergeScanner::new(vec![Scanner::new(&blob_file_path, 0)?]);
+            let mut merger = MergeScanner::new(vec![Scanner::new(&blob_file_path, 0, false)?]);
 
             assert_eq!(
                 (Slice::from(b"a"), Slice::from(b"1".repeat(100))),
@@ -153,7 +153,7 @@ mod tests {
             let keys = [b"a", b"c", b"e"];
 
             {
-                let mut writer = BlobFileWriter::new(&blob_file_0_path, 0, 0)?;
+                let mut writer = BlobFileWriter::new(&blob_file_0_path, 0, 0, false)?;
 
                 for key in keys {
                     writer.write(key, 0, &key.repeat(100))?;
@@ -167,7 +167,7 @@ mod tests {
             let keys = [b"b", b"d"];
 
             {
-                let mut writer = BlobFileWriter::new(&blob_file_1_path, 1, 0)?;
+                let mut writer = BlobFileWriter::new(&blob_file_1_path, 1, 0, false)?;
 
                 for key in keys {
                     writer.write(key, 1, &key.repeat(100))?;
@@ -179,8 +179,8 @@ mod tests {
 
         {
             let mut merger = MergeScanner::new(vec![
-                Scanner::new(&blob_file_0_path, 0)?,
-                Scanner::new(&blob_file_1_path, 1)?,
+                Scanner::new(&blob_file_0_path, 0, false)?,
+                Scanner::new(&blob_file_1_path, 1, false)?,
             ]);
 
             let merged_keys = [b"a", b"b", b"c", b"d", b"e"];

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -33,10 +33,17 @@ pub struct MultiWriter {
 
     tree_id: TreeId,
     descriptor_table: Option<Arc<DescriptorTable>>,
+
+    /// Propagated to per-blob-file `Writer` construction. Mirrors the table writer's
+    /// `use_direct_io` plumbing.
+    use_direct_io: bool,
 }
 
 impl MultiWriter {
     /// Initializes a new blob file writer.
+    ///
+    /// Constructs a `MultiWriter`. When `use_direct_io` is `true` each
+    /// per-blob-file `Writer` is opened with platform direct I/O.
     ///
     /// # Errors
     ///
@@ -47,6 +54,7 @@ impl MultiWriter {
         folder: P,
         tree_id: TreeId,
         descriptor_table: Option<Arc<DescriptorTable>>,
+        use_direct_io: bool,
     ) -> crate::Result<Self> {
         let folder = folder.as_ref();
 
@@ -58,7 +66,7 @@ impl MultiWriter {
             folder: folder.into(),
             target_size: 64 * 1_024 * 1_024,
 
-            active_writer: Writer::new(blob_file_path, blob_file_id, tree_id)?,
+            active_writer: Writer::new(blob_file_path, blob_file_id, tree_id, use_direct_io)?,
 
             results: Vec::new(),
 
@@ -67,6 +75,8 @@ impl MultiWriter {
 
             tree_id,
             descriptor_table,
+
+            use_direct_io,
         })
     }
 
@@ -103,8 +113,14 @@ impl MultiWriter {
         let new_blob_file_id = self.id_generator.next();
         let blob_file_path = self.folder.join(new_blob_file_id.to_string());
 
-        let new_writer = Writer::new(blob_file_path, new_blob_file_id, self.tree_id)?
-            .use_compression(self.compression);
+        // Each rotated blob file must use the same I/O mode as its predecessors.
+        let new_writer = Writer::new(
+            blob_file_path,
+            new_blob_file_id,
+            self.tree_id,
+            self.use_direct_io,
+        )?
+        .use_compression(self.compression);
 
         let old_writer = std::mem::replace(&mut self.active_writer, new_writer);
         let blob_file = Self::consume_writer(
@@ -172,10 +188,17 @@ impl MultiWriter {
                 writer.path.display(),
             );
 
-            if let Err(e) = std::fs::remove_file(&writer.path) {
+            // Drop the writer first via `cancel_for_delete` so the underlying
+            // AlignedFileWriter (if any) does not pad+truncate a file we're about
+            // to remove. Wasted I/O on Unix; can be flat-out broken on Windows
+            // (ERROR_ACCESS_DENIED on a marked-for-deletion handle).
+            let path = writer.path.clone();
+            writer.cancel_for_delete();
+
+            if let Err(e) = std::fs::remove_file(&path) {
                 log::warn!(
                     "Could not delete empty blob file at {}: {e:?}",
-                    writer.path.display(),
+                    path.display(),
                 );
             }
 

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -118,8 +118,9 @@ mod tests {
         let id_generator = SequenceNumberCounter::default();
 
         let folder = tempfile::tempdir()?;
-        let mut writer = crate::vlog::BlobFileWriter::new(id_generator, folder.path(), 0, None)?
-            .use_target_size(u64::MAX);
+        let mut writer =
+            crate::vlog::BlobFileWriter::new(id_generator, folder.path(), 0, None, false)?
+                .use_target_size(u64::MAX);
 
         let handle = writer.write(b"a", 0, b"abcdef")?;
 
@@ -140,9 +141,10 @@ mod tests {
         let id_generator = SequenceNumberCounter::default();
 
         let folder = tempfile::tempdir()?;
-        let mut writer = crate::vlog::BlobFileWriter::new(id_generator, folder.path(), 0, None)?
-            .use_target_size(u64::MAX)
-            .use_compression(CompressionType::Lz4);
+        let mut writer =
+            crate::vlog::BlobFileWriter::new(id_generator, folder.path(), 0, None, false)?
+                .use_target_size(u64::MAX)
+                .use_compression(CompressionType::Lz4);
 
         let handle0 = writer.write(b"a", 0, b"abcdef")?;
         let handle1 = writer.write(b"b", 0, b"ghi")?;

--- a/src/vlog/blob_file/scanner.rs
+++ b/src/vlog/blob_file/scanner.rs
@@ -23,7 +23,7 @@ pub struct Scanner {
 
 impl Scanner {
     /// Initializes a new blob file reader. When `use_direct_io` is `true` the
-    /// underlying file is opened with platform direct I/O — what the compaction
+    /// underlying file is opened with platform direct I/O, which the compaction
     /// worker passes when [`crate::Config::use_direct_io_for_compaction_reads`]
     /// is on during blob relocation.
     ///
@@ -64,9 +64,8 @@ impl Iterator for Scanner {
 
         // Track bytes consumed locally; commit to `self.pos` only after the entire
         // entry parses cleanly. Partial increments on a parse failure would leave
-        // `self.pos` inconsistent with the kernel's file position and break the
-        // recorded `offset` of any future entry (mostly defensive — callers do not
-        // iterate past errors today).
+        // `self.pos` inconsistent and break the recorded `offset` of any later
+        // entry. Mostly defensive: callers do not iterate past errors today.
         let offset = self.pos;
         let mut delta: u64 = 0;
 

--- a/src/vlog/blob_file/scanner.rs
+++ b/src/vlog/blob_file/scanner.rs
@@ -4,42 +4,44 @@
 
 use super::writer::BLOB_HEADER_MAGIC;
 use crate::{
+    direct_io::ChunkedReader,
     vlog::{blob_file::meta::METADATA_HEADER_MAGIC, BlobFileId},
     Checksum, SeqNo, UserKey, UserValue,
 };
 use byteorder::{LittleEndian, ReadBytesExt};
-use std::{
-    fs::File,
-    io::{BufReader, Read, Seek},
-    path::Path,
-};
+use std::{io::Read, path::Path};
 
 /// Reads through a blob file in order
 pub struct Scanner {
     pub(crate) blob_file_id: BlobFileId, // TODO: remove unused?
-    inner: BufReader<File>,
+    inner: ChunkedReader,
     is_terminated: bool,
+    /// Logical byte offset within the file (manually tracked because `ChunkedReader`
+    /// does not implement `Seek`). Used to record each scan entry's offset.
+    pos: u64,
 }
 
 impl Scanner {
-    /// Initializes a new blob file reader.
+    /// Initializes a new blob file reader. When `use_direct_io` is `true` the
+    /// underlying file is opened with platform direct I/O — what the compaction
+    /// worker passes when [`crate::Config::use_direct_io_for_compaction_reads`]
+    /// is on during blob relocation.
     ///
     /// # Errors
     ///
     /// Will return `Err` if an IO error occurs.
-    pub fn new<P: AsRef<Path>>(path: P, blob_file_id: BlobFileId) -> crate::Result<Self> {
-        let file_reader = BufReader::with_capacity(32_000, File::open(path)?);
-        Ok(Self::with_reader(blob_file_id, file_reader))
-    }
-
-    /// Initializes a new blob file reader.
-    #[must_use]
-    pub fn with_reader(blob_file_id: BlobFileId, file_reader: BufReader<File>) -> Self {
-        Self {
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        blob_file_id: BlobFileId,
+        use_direct_io: bool,
+    ) -> crate::Result<Self> {
+        let reader = ChunkedReader::open(path.as_ref(), use_direct_io)?;
+        Ok(Self {
             blob_file_id,
-            inner: file_reader,
+            inner: reader,
             is_terminated: false,
-        }
+            pos: 0,
+        })
     }
 }
 
@@ -60,37 +62,56 @@ impl Iterator for Scanner {
             return None;
         }
 
-        let offset = fail_iter!(self.inner.stream_position());
+        // Track bytes consumed locally; commit to `self.pos` only after the entire
+        // entry parses cleanly. Partial increments on a parse failure would leave
+        // `self.pos` inconsistent with the kernel's file position and break the
+        // recorded `offset` of any future entry (mostly defensive — callers do not
+        // iterate past errors today).
+        let offset = self.pos;
+        let mut delta: u64 = 0;
 
         {
             let mut buf = [0; BLOB_HEADER_MAGIC.len()];
             fail_iter!(self.inner.read_exact(&mut buf));
+            delta += BLOB_HEADER_MAGIC.len() as u64;
 
             if buf == METADATA_HEADER_MAGIC {
                 self.is_terminated = true;
+                self.pos += delta;
                 return None;
             }
 
             if buf != BLOB_HEADER_MAGIC {
+                self.pos += delta;
                 return Some(Err(crate::Error::InvalidHeader("Blob")));
             }
         }
 
         let expected_checksum = fail_iter!(self.inner.read_u128::<LittleEndian>());
+        delta += std::mem::size_of::<u128>() as u64;
+
         let seqno = fail_iter!(self.inner.read_u64::<LittleEndian>());
+        delta += std::mem::size_of::<u64>() as u64;
 
         let key_len = fail_iter!(self.inner.read_u16::<LittleEndian>());
+        delta += std::mem::size_of::<u16>() as u64;
 
         let real_val_len = fail_iter!(self.inner.read_u32::<LittleEndian>());
+        delta += std::mem::size_of::<u32>() as u64;
 
         let on_disk_val_len = fail_iter!(self.inner.read_u32::<LittleEndian>());
+        delta += std::mem::size_of::<u32>() as u64;
 
         let key = fail_iter!(UserKey::from_reader(&mut self.inner, key_len as usize));
+        delta += u64::from(key_len);
 
         let value = fail_iter!(UserValue::from_reader(
             &mut self.inner,
             on_disk_val_len as usize
         ));
+        delta += u64::from(on_disk_val_len);
+
+        self.pos += delta;
 
         {
             let checksum = {
@@ -139,7 +160,7 @@ mod tests {
         let keys = [b"a", b"b", b"c", b"d", b"e"];
 
         {
-            let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0)?;
+            let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0, false)?;
 
             for key in keys {
                 writer.write(key, 0, &key.repeat(100))?;
@@ -149,7 +170,7 @@ mod tests {
         }
 
         {
-            let mut scanner = Scanner::new(&blob_file_path, 0)?;
+            let mut scanner = Scanner::new(&blob_file_path, 0, false)?;
 
             for key in keys {
                 assert_eq!(

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -4,13 +4,12 @@
 
 use super::meta::Metadata;
 use crate::{
-    checksum::ChecksummedWriter, time::unix_timestamp, vlog::BlobFileId, Checksum, CompressionType,
-    KeyRange, SeqNo, TreeId, UserKey,
+    checksum::ChecksummedWriter, direct_io::ChunkedWriter, time::unix_timestamp, vlog::BlobFileId,
+    Checksum, CompressionType, KeyRange, SeqNo, TreeId, UserKey,
 };
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::{
-    fs::File,
-    io::{BufWriter, Write},
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -30,7 +29,7 @@ pub struct Writer {
     pub(crate) blob_file_id: BlobFileId,
 
     #[expect(clippy::struct_field_names)]
-    writer: sfa::Writer<ChecksummedWriter<BufWriter<File>>>,
+    writer: sfa::Writer<ChecksummedWriter<ChunkedWriter>>,
 
     offset: u64,
 
@@ -50,15 +49,18 @@ impl Writer {
     /// # Errors
     ///
     /// Will return `Err` if an IO error occurs.
-    #[doc(hidden)]
+    ///
+    /// When `use_direct_io` is `true` the underlying file is opened with
+    /// platform direct I/O.
     pub fn new<P: AsRef<Path>>(
         path: P,
         blob_file_id: BlobFileId,
         tree_id: TreeId,
+        use_direct_io: bool,
     ) -> crate::Result<Self> {
         let path = path.as_ref();
 
-        let writer = BufWriter::new(File::create(path)?);
+        let writer = ChunkedWriter::create_or_truncate(path, use_direct_io)?;
         let writer = ChecksummedWriter::new(writer);
         let mut writer = sfa::Writer::from_writer(writer);
         writer.start("data")?;
@@ -204,6 +206,20 @@ impl Writer {
         self.write_raw(key, seqno, value, value.len() as u32)
     }
 
+    /// Discards buffered data and releases the underlying file without padding or
+    /// truncating. The caller is expected to immediately remove the file from disk.
+    pub(crate) fn cancel_for_delete(self) {
+        let checksum_writer = match self.writer.into_inner() {
+            Ok(w) => w,
+            Err(e) => {
+                log::warn!("Discarding blob file writer with sfa::Writer error: {e:?}");
+                return;
+            }
+        };
+        let (chunked, _) = checksum_writer.into_inner();
+        drop(chunked.cancel());
+    }
+
     pub(crate) fn finish(mut self) -> crate::Result<(Metadata, Checksum)> {
         self.writer.start("meta")?;
 
@@ -227,9 +243,12 @@ impl Writer {
         };
         metadata.encode_into(&mut self.writer)?;
 
-        let mut checksum = self.writer.into_inner()?;
-        checksum.inner_mut().get_mut().sync_all()?;
-        let checksum = checksum.checksum();
+        // Drain sfa and ChecksummedWriter wrappers, then finalize the chunked writer
+        // (zero-pad + truncate for direct-I/O mode) before issuing the final fsync.
+        let checksum_writer = self.writer.into_inner()?;
+        let (chunked, checksum) = checksum_writer.into_inner();
+        let file = chunked.finalize()?;
+        file.sync_all()?;
 
         Ok((metadata, checksum))
     }

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -244,7 +244,8 @@ impl Writer {
         metadata.encode_into(&mut self.writer)?;
 
         // Drain sfa and ChecksummedWriter wrappers, then finalize the chunked writer
-        // (zero-pad + truncate for direct-I/O mode) before issuing the final fsync.
+        // (drains the buffered tail to the exact byte count in direct-I/O mode)
+        // before issuing the final fsync.
         let checksum_writer = self.writer.into_inner()?;
         let (chunked, checksum) = checksum_writer.into_inner();
         let file = chunked.finalize()?;

--- a/tests/direct_io_bench_values.rs
+++ b/tests/direct_io_bench_values.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+#[path = "../examples/direct_io_bench.rs"]
+#[allow(dead_code)]
+mod direct_io_bench;
+
+use std::collections::HashSet;
+
+#[test]
+fn direct_io_bench_payload_filler_is_deterministic_and_seeded() {
+    let mut first = vec![0; 4_096];
+    let mut first_again = vec![0; 4_096];
+    let mut second = vec![0; 4_096];
+
+    direct_io_bench::fill_incompressible_value(&mut first, 1);
+    direct_io_bench::fill_incompressible_value(&mut first_again, 1);
+    direct_io_bench::fill_incompressible_value(&mut second, 2);
+
+    assert_eq!(first, first_again);
+    assert_ne!(first, second);
+
+    let unique_chunks = first
+        .chunks(8)
+        .take(64)
+        .map(<[u8]>::to_vec)
+        .collect::<HashSet<_>>();
+    assert!(
+        unique_chunks.len() > 48,
+        "payload should vary across chunks instead of repeating one 8-byte pattern",
+    );
+}

--- a/tests/direct_io_flush_and_compaction.rs
+++ b/tests/direct_io_flush_and_compaction.rs
@@ -1,0 +1,526 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+//! Integration tests covering the `use_direct_io_for_compaction_reads` and
+//! `use_direct_io_for_flush_and_compaction` config knobs.
+//!
+//! Each test exercises a full flush + compaction round-trip with one or both
+//! direct-I/O knobs enabled and then verifies the data is readable and correct.
+//! Covered permutations: writes-only, reads-only, both, and the buffered baseline.
+
+use lsm_tree::{
+    get_tmp_folder, AbstractTree, Config, KvSeparationOptions, SeqNo, SequenceNumberCounter,
+};
+use std::sync::Arc;
+#[cfg(all(target_os = "linux", debug_assertions))]
+use std::{
+    ffi::OsString,
+    fs::{File, OpenOptions},
+    io::Write,
+    os::unix::fs::OpenOptionsExt,
+    path::Path,
+};
+use test_log::test;
+
+fn populate_keys(
+    tree: &lsm_tree::AnyTree,
+    range: std::ops::Range<u32>,
+    seqno: &SequenceNumberCounter,
+) {
+    for i in range {
+        let key = format!("k{i:08}");
+        let value = format!("v{i:08}_payload_data_to_make_values_a_bit_larger");
+        tree.insert(key.as_bytes(), value.as_bytes(), seqno.next());
+    }
+}
+
+fn verify_keys(tree: &lsm_tree::AnyTree, range: std::ops::Range<u32>) -> lsm_tree::Result<()> {
+    for i in range {
+        let key = format!("k{i:08}");
+        let expected = format!("v{i:08}_payload_data_to_make_values_a_bit_larger");
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(expected.as_bytes()),
+            "key {key} did not round-trip",
+        );
+    }
+    Ok(())
+}
+
+// Builds a config with the two direct-I/O knobs set as requested. Returns the
+// seqno counter so each test can pass it to `populate_keys` to keep the global
+// counter consistent with what the tree sees on flush/compact.
+fn config_with(
+    folder: &std::path::Path,
+    direct_writes: bool,
+    direct_reads: bool,
+) -> (Config, SequenceNumberCounter) {
+    let seqno = SequenceNumberCounter::default();
+    let cfg = Config::new(folder, seqno.clone(), SequenceNumberCounter::default())
+        .use_direct_io_for_flush_and_compaction(direct_writes)
+        .use_direct_io_for_compaction_reads(direct_reads);
+    (cfg, seqno)
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+const TEST_MAX_READ_BYTES_ENV: &str = "LSM_TREE_TEST_DIRECT_IO_MAX_READ_BYTES";
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+struct ForcedDirectReadLimitGuard {
+    previous: Option<OsString>,
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+impl ForcedDirectReadLimitGuard {
+    fn set(max_read_bytes: usize) -> Self {
+        let previous = std::env::var_os(TEST_MAX_READ_BYTES_ENV);
+        std::env::set_var(TEST_MAX_READ_BYTES_ENV, max_read_bytes.to_string());
+        Self { previous }
+    }
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+impl Drop for ForcedDirectReadLimitGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(TEST_MAX_READ_BYTES_ENV, previous);
+        } else {
+            std::env::remove_var(TEST_MAX_READ_BYTES_ENV);
+        }
+    }
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+fn direct_io_alignment_for_test() -> usize {
+    // SAFETY: sysconf is called with a constant and has no aliasing requirements.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    match usize::try_from(page_size) {
+        Ok(v) if v >= 512 && v.is_power_of_two() => v,
+        _ => 4_096,
+    }
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+fn filesystem_accepts_direct_io(dir: &Path, alignment: usize) -> std::io::Result<bool> {
+    let path = dir.join(".direct_io_probe");
+    {
+        let mut file = File::create(&path)?;
+        file.write_all(&vec![0; alignment])?;
+        file.sync_all()?;
+    }
+
+    let opened = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECT)
+        .open(&path);
+    let _ = std::fs::remove_file(&path);
+
+    match opened {
+        Ok(_) => Ok(true),
+        Err(e) if e.raw_os_error() == Some(libc::EINVAL) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+#[test]
+fn direct_io_buffered_baseline_roundtrip() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(
+        folder.path(),
+        seqno.clone(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    // Sanity baseline so the "direct I/O on" tests below have a comparable shape.
+    populate_keys(&tree, 0..500, &seqno);
+    tree.flush_active_memtable(0)?;
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+    verify_keys(&tree, 0..500)?;
+    Ok(())
+}
+
+#[test]
+fn direct_io_writes_only_flush_and_compact() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, false);
+    let tree = cfg.open()?;
+
+    populate_keys(&tree, 0..500, &seqno);
+    tree.flush_active_memtable(0)?;
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+
+    verify_keys(&tree, 0..500)?;
+    Ok(())
+}
+
+#[test]
+fn direct_io_reads_only_flush_and_compact() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), false, true);
+    let tree = cfg.open()?;
+
+    populate_keys(&tree, 0..500, &seqno);
+    tree.flush_active_memtable(0)?;
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+
+    verify_keys(&tree, 0..500)?;
+    Ok(())
+}
+
+#[test]
+fn direct_io_reads_and_writes_flush_and_compact() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, true);
+    let tree = cfg.open()?;
+
+    populate_keys(&tree, 0..500, &seqno);
+    tree.flush_active_memtable(0)?;
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+
+    verify_keys(&tree, 0..500)?;
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+#[test]
+fn direct_io_compaction_reads_continue_after_aligned_short_read_before_eof() -> lsm_tree::Result<()>
+{
+    use lsm_tree::config::CompressionPolicy;
+    use lsm_tree::CompressionType;
+
+    let folder = get_tmp_folder();
+    let alignment = direct_io_alignment_for_test();
+    if !filesystem_accepts_direct_io(folder.path(), alignment)? {
+        eprintln!("filesystem does not support direct I/O; skipping short-read assertion");
+        return Ok(());
+    }
+
+    let _guard = ForcedDirectReadLimitGuard::set(alignment);
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(
+        folder.path(),
+        seqno.clone(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .use_direct_io_for_compaction_reads(true)
+    .open()?;
+
+    for batch in 0..4 {
+        let start = batch * 700;
+        let end = start + 700;
+        for i in start..end {
+            let key = format!("k{i:08}");
+            let value = format!("v{i:08}_short_read_payload_").repeat(12);
+            tree.insert(key.as_bytes(), value.as_bytes(), seqno.next());
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    tree.major_compact(128 * 1_024, 0)?;
+
+    for i in 0..2_800 {
+        let key = format!("k{i:08}");
+        let expected = format!("v{i:08}_short_read_payload_").repeat(12);
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(expected.as_bytes()),
+            "key {key} did not round-trip after forced short direct reads",
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn direct_io_multiple_flushes_then_compaction() -> lsm_tree::Result<()> {
+    // Exercises rotation across multiple SSTs in both flush + compaction with the
+    // direct I/O paths active.
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, true);
+    let tree = cfg.open()?;
+
+    for batch in 0..5 {
+        let lo = batch * 200;
+        let hi = lo + 200;
+        populate_keys(&tree, lo..hi, &seqno);
+        tree.flush_active_memtable(0)?;
+    }
+
+    assert!(tree.table_count() >= 5);
+
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+
+    verify_keys(&tree, 0..1_000)?;
+    Ok(())
+}
+
+#[test]
+fn direct_io_with_tombstones() -> lsm_tree::Result<()> {
+    // Tombstone propagation through a direct-I/O compaction must still drop the
+    // corresponding inserts on the last level.
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, true);
+    let tree = cfg.open()?;
+
+    populate_keys(&tree, 0..200, &seqno);
+    tree.flush_active_memtable(0)?;
+
+    for i in 0..100 {
+        let key = format!("k{i:08}");
+        tree.remove(key.as_bytes(), seqno.next());
+    }
+    tree.flush_active_memtable(0)?;
+
+    tree.major_compact(64 * 1_024 * 1_024, seqno.get())?;
+
+    for i in 0..100 {
+        let key = format!("k{i:08}");
+        assert!(
+            tree.get(key.as_bytes(), SeqNo::MAX)?.is_none(),
+            "removed {key} should not exist",
+        );
+    }
+    verify_keys(&tree, 100..200)?;
+    Ok(())
+}
+
+#[cfg(feature = "lz4")]
+#[test]
+fn direct_io_with_lz4_compression() -> lsm_tree::Result<()> {
+    use lsm_tree::config::CompressionPolicy;
+    use lsm_tree::CompressionType;
+
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(
+        folder.path(),
+        seqno.clone(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::Lz4))
+    .use_direct_io_for_flush_and_compaction(true)
+    .use_direct_io_for_compaction_reads(true)
+    .open()?;
+
+    populate_keys(&tree, 0..500, &seqno);
+    tree.flush_active_memtable(0)?;
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+    verify_keys(&tree, 0..500)?;
+    Ok(())
+}
+
+#[test]
+fn direct_io_blob_tree_flush_and_compact() -> lsm_tree::Result<()> {
+    // Blob tree exercises both SST and blob-file writers, plus the blob scanner
+    // during relocation. All three direct-I/O paths must produce correct data.
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(
+        folder.path(),
+        seqno.clone(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(8)))
+    .use_direct_io_for_flush_and_compaction(true)
+    .use_direct_io_for_compaction_reads(true)
+    .open()?;
+
+    // Values are larger than the separation threshold so they go to blob files.
+    for i in 0..200 {
+        let key = format!("blobkey_{i:06}");
+        let value = format!("blobval_{i:06}_").repeat(20); // ~280 bytes per value
+        tree.insert(key.as_bytes(), value.as_bytes(), seqno.next());
+    }
+
+    tree.flush_active_memtable(0)?;
+    assert!(tree.blob_file_count() >= 1);
+
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+
+    for i in 0..200 {
+        let key = format!("blobkey_{i:06}");
+        let expected = format!("blobval_{i:06}_").repeat(20);
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(expected.as_bytes()),
+            "blob {key} did not round-trip"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn direct_io_minor_compaction_with_partial_block_tail() -> lsm_tree::Result<()> {
+    // Stress the AlignedFileWriter's trailing-block padding+truncate path: write a
+    // small enough payload that the on-disk file size is much less than the page
+    // alignment unit.
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, true);
+    let tree = cfg.open()?;
+
+    // A handful of tiny KVs: the entire SST tail (incl. meta) will be < 1 page.
+    for i in 0..3 {
+        tree.insert(
+            format!("k{i}").as_bytes(),
+            format!("v{i}").as_bytes(),
+            seqno.next(),
+        );
+    }
+    tree.flush_active_memtable(0)?;
+
+    for i in 0..3 {
+        let key = format!("k{i}");
+        let expected = format!("v{i}");
+        assert_eq!(
+            tree.get(key.as_bytes(), SeqNo::MAX)?.as_deref(),
+            Some(expected.as_bytes()),
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn direct_io_knob_compatible_with_drop_range() -> lsm_tree::Result<()> {
+    // drop_range goes through the Choice::Drop compaction path, not Merge, so it
+    // never opens compaction-input files. This test only confirms that enabling the
+    // direct-I/O knob does not surprise the drop path.
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, true);
+    let tree = cfg.open()?;
+
+    populate_keys(&tree, 0..100, &seqno);
+    tree.flush_active_memtable(0)?;
+    let table_count_before = tree.table_count();
+    assert!(table_count_before >= 1);
+
+    // Fully contains every k00000000..k00000099 produced above.
+    tree.drop_range::<&[u8], _>(..)?;
+    assert_eq!(0, tree.table_count(), "all tables should have been dropped");
+    for i in 0..100 {
+        let key = format!("k{i:08}");
+        assert!(tree.get(key.as_bytes(), SeqNo::MAX)?.is_none());
+    }
+    Ok(())
+}
+
+#[test]
+fn direct_io_reopen_persists_data() -> lsm_tree::Result<()> {
+    // Direct I/O is purely a runtime knob — the on-disk format is identical. A
+    // database written with direct I/O on must be readable when reopened with the
+    // knob off, and vice versa.
+    let folder = get_tmp_folder();
+
+    {
+        let (cfg, seqno) = config_with(folder.path(), true, true);
+        let tree = cfg.open()?;
+        populate_keys(&tree, 0..200, &seqno);
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(64 * 1_024 * 1_024, 0)?;
+    }
+
+    // Reopen with the knob off; data must be intact.
+    {
+        let (cfg, _seqno) = config_with(folder.path(), false, false);
+        let tree = cfg.open()?;
+        verify_keys(&tree, 0..200)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn direct_io_multi_pass_compaction() -> lsm_tree::Result<()> {
+    // Multiple compaction passes exercise the read+write paths repeatedly with the
+    // same file handles, catching state-corruption issues that single-pass tests miss.
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, true);
+    let tree = cfg.open()?;
+
+    for pass in 0..3 {
+        let base = pass * 300;
+        populate_keys(&tree, base..(base + 300), &seqno);
+        tree.flush_active_memtable(0)?;
+        tree.compact(
+            Arc::new(lsm_tree::compaction::Fifo::new(64 * 1_024 * 1_024, None)),
+            0,
+        )?;
+    }
+
+    verify_keys(&tree, 0..900)?;
+    Ok(())
+}
+
+#[test]
+fn direct_io_multi_writer_rotation_with_direct_io() -> lsm_tree::Result<()> {
+    // Drives a single major compaction that produces enough output to force
+    // `MultiWriter::rotate` (which re-opens a fresh direct-I/O file mid-compaction)
+    // by setting a small target_size. This is the missing-rotation-test gap surfaced
+    // by the review.
+    //
+    // Compression is explicitly disabled because with LZ4 the highly-repetitive
+    // payload compresses well enough to fit a single table.
+    use lsm_tree::config::CompressionPolicy;
+    use lsm_tree::CompressionType;
+
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(
+        folder.path(),
+        seqno.clone(),
+        SequenceNumberCounter::default(),
+    )
+    .use_direct_io_for_flush_and_compaction(true)
+    .use_direct_io_for_compaction_reads(true)
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .open()?;
+
+    // Each value is ~256 bytes; 8_000 keys = ~2 MiB of user data, easily forcing
+    // multiple rotations with the 256 KiB target_size below.
+    let value = "v_payload_padding_padding_padding_padding_padding_padding".repeat(4);
+    for i in 0..8_000_u32 {
+        let key = format!("k{i:08}");
+        tree.insert(key.as_bytes(), value.as_bytes(), seqno.next());
+    }
+    tree.flush_active_memtable(0)?;
+
+    // major_compact with small target_size triggers MultiWriter::rotate.
+    tree.major_compact(256 * 1_024, 0)?;
+    assert!(
+        tree.table_count() >= 2,
+        "compaction with small target_size should produce multiple output tables, got {}",
+        tree.table_count(),
+    );
+
+    for i in 0..8_000_u32 {
+        let key = format!("k{i:08}");
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(value.as_bytes()),
+            "key {key} did not round-trip after rotation",
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn direct_io_falls_back_on_unsupported_filesystem() -> lsm_tree::Result<()> {
+    // The knob is documented as silently falling back to buffered I/O on
+    // filesystems that reject direct I/O (e.g. tmpfs/overlayfs/FUSE). On macOS
+    // F_NOCACHE is universally accepted, on Linux/Windows the FS may reject;
+    // either way the tree must operate correctly and the data must round-trip.
+    let folder = get_tmp_folder();
+    let (cfg, seqno) = config_with(folder.path(), true, true);
+    let tree = cfg.open()?;
+    populate_keys(&tree, 0..100, &seqno);
+    tree.flush_active_memtable(0)?;
+    tree.major_compact(64 * 1_024 * 1_024, 0)?;
+    verify_keys(&tree, 0..100)?;
+    Ok(())
+}

--- a/tests/direct_io_flush_and_compaction.rs
+++ b/tests/direct_io_flush_and_compaction.rs
@@ -356,6 +356,58 @@ fn direct_io_blob_tree_flush_and_compact() -> lsm_tree::Result<()> {
 }
 
 #[test]
+fn direct_io_blob_relocation_runs_scanner() -> lsm_tree::Result<()> {
+    // Overwriting a separated value makes its original blob file stale; the next
+    // major compaction relocates the *surviving* entries out of that file via
+    // `BlobFileScanner`. With both direct-I/O knobs on, this exercises the
+    // scanner's manual offset-summation (which replaced `stream_position`) under
+    // direct I/O — a path the no-overwrite blob test above never reaches.
+    // Mirrors `blob_tree_major_compact_relocation_simple`, which proves the
+    // sequence relocates; here we additionally assert values survive direct I/O.
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let tree = Config::new(
+        folder.path(),
+        seqno.clone(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default().age_cutoff(1.0)))
+    .use_direct_io_for_flush_and_compaction(true)
+    .use_direct_io_for_compaction_reads(true)
+    .open()?;
+
+    let big = b"neptune!".repeat(2_000); // ~16 KiB -> separated into a blob file
+    let new_big = b"winter!".repeat(2_000);
+
+    tree.insert("big", &big, seqno.next());
+    tree.insert("big2", &big, seqno.next());
+    tree.flush_active_memtable(0)?;
+    assert_eq!(tree.blob_file_count(), 1);
+
+    // Overwrite "big": its original blob entry becomes garbage, making the first
+    // blob file stale (1 of 2 entries dead = 50% >= default staleness threshold).
+    tree.insert("big", &new_big, seqno.next());
+    tree.flush_active_memtable(0)?;
+
+    tree.major_compact(64 * 1_024 * 1_024, seqno.next())?;
+    // First blob dropped; its live entry ("big2") relocated into a fresh blob,
+    // alongside the second-generation "big" blob => 2 blob files.
+    assert_eq!(tree.blob_file_count(), 2);
+
+    assert_eq!(
+        tree.get("big", SeqNo::MAX)?.as_deref(),
+        Some(new_big.as_slice()),
+        "overwritten value did not round-trip",
+    );
+    assert_eq!(
+        tree.get("big2", SeqNo::MAX)?.as_deref(),
+        Some(big.as_slice()),
+        "relocated value did not round-trip",
+    );
+    Ok(())
+}
+
+#[test]
 fn direct_io_minor_compaction_with_partial_block_tail() -> lsm_tree::Result<()> {
     // Stress the AlignedFileWriter's trailing-block padding+truncate path: write a
     // small enough payload that the on-disk file size is much less than the page

--- a/tests/direct_io_flush_and_compaction.rs
+++ b/tests/direct_io_flush_and_compaction.rs
@@ -358,12 +358,11 @@ fn direct_io_blob_tree_flush_and_compact() -> lsm_tree::Result<()> {
 #[test]
 fn direct_io_blob_relocation_runs_scanner() -> lsm_tree::Result<()> {
     // Overwriting a separated value makes its original blob file stale; the next
-    // major compaction relocates the *surviving* entries out of that file via
-    // `BlobFileScanner`. With both direct-I/O knobs on, this exercises the
-    // scanner's manual offset-summation (which replaced `stream_position`) under
-    // direct I/O — a path the no-overwrite blob test above never reaches.
-    // Mirrors `blob_tree_major_compact_relocation_simple`, which proves the
-    // sequence relocates; here we additionally assert values survive direct I/O.
+    // major compaction relocates the surviving entries out of that file via
+    // BlobFileScanner. With both direct-I/O knobs on, this runs the scanner's
+    // manual offset-summation (which replaced stream_position) under direct I/O,
+    // which the no-overwrite blob test above never does. Mirrors
+    // blob_tree_major_compact_relocation_simple, plus a value round-trip check.
     let folder = get_tmp_folder();
     let seqno = SequenceNumberCounter::default();
     let tree = Config::new(
@@ -463,7 +462,7 @@ fn direct_io_knob_compatible_with_drop_range() -> lsm_tree::Result<()> {
 
 #[test]
 fn direct_io_reopen_persists_data() -> lsm_tree::Result<()> {
-    // Direct I/O is purely a runtime knob — the on-disk format is identical. A
+    // Direct I/O is purely a runtime knob; the on-disk format is identical. A
     // database written with direct I/O on must be readable when reopened with the
     // knob off, and vice versa.
     let folder = get_tmp_folder();


### PR DESCRIPTION
Two opt-in Config flags for direct I/O during compaction and flush. Both default to `false` and the on-disk format is unchanged, so you can flip them across reopens.

- `use_direct_io_for_compaction_reads`: compaction reads SST and blob files with `O_DIRECT` (Linux) or `F_NOCACHE` (macOS), keeping the sequential read-once scan out of the OS page cache.
- `use_direct_io_for_flush_and_compaction`: flush, ingest, and compaction-output writes go through the same direct path. Same idea, but for write-once data.

If the filesystem rejects `O_DIRECT` (`EINVAL` on tmpfs, overlayfs, some FUSE filesystems), the open falls back to buffered I/O and logs a warning once. On Windows and other platforms without a direct-I/O primitive, the flags are no-ops.

Builds on RocksDB's [direct-I/O options](https://github.com/facebook/rocksdb/pull/14743).

## Why

On write-heavy workloads with continuous compaction, the page cache fills up with compaction's read-once data and evicts the pages that user reads actually want. Reads then have to go to disk and tail latency suffers. Direct I/O fixes this by keeping compaction's reads and writes out of the page cache entirely.

## Benchmark

Same methodology as the RocksDB PR. Host: Apple M4 Pro, 48 GiB, Docker Desktop running a Linux aarch64 VM. Container memory cgroup: 1 GiB. DB on disk: 4 034 MiB (1M keys, 4 096 B of incompressible values per key, so the working set is 4× the cache). Hot reader set: 4 000 keys (~16 MiB). Writer throttled to 10 MiB/s. 30 s per config plus 10 s warmup, one fresh container per config so the page cache always starts cold. N=3 iterations, means reported. Full methodology and per-iteration data in [`examples/DIRECT_IO_BENCH.md`](examples/DIRECT_IO_BENCH.md).

### Headline result, N=3 mean

| Config       | Throughput  | P50 (µs) | P99 (µs) | P99.9 (µs) | P99.99 (µs) |
|--------------|------------:|---------:|---------:|-----------:|------------:|
| buffered     | 670 941     | 4.79     | 17.49    | 54.49      | 237.03      |
| writes_only  | 716 707     | 4.68     | 16.42    | 39.28      | 141.29      |
| reads_only   | 746 252     | 4.46     | 15.36    | 37.83      | 196.75      |
| **both**     | **738 635** | **4.44** | **15.78**| **39.47**  | **142.71**  |

vs buffered:

| Config       | Throughput | P50    | P99    | P99.9  | P99.99 |
|--------------|-----------:|-------:|-------:|-------:|-------:|
| writes_only  | +6.8 %     | −2.2 % | −6.1 % | −27.9% | **−40.4%** |
| reads_only   | +11.2 %    | −6.9 % | −12.2% | −30.6% | −17.0% |
| **both**     | **+10.1%** | −7.3 % | −9.8 % | −27.6% | **−39.8%** |

So roughly: P99.99 down ~40%, throughput up ~10%, in a 4× cache oversubscription scenario.

One thing worth calling out: `reads_only` wins less at P99.99 than `writes_only`. That's because direct compaction reads also bypass the kernel's readahead, and lsm-tree doesn't have a userspace prefetch for compaction reads yet (the equivalent of RocksDB's `compaction_readahead_size`). So the read flag has to make up for the missing readahead via the cache-protection benefit. The write flag doesn't have that tradeoff because flush and compaction-output is write-once, nothing to read back.

### Recommended

Turn `use_direct_io_for_flush_and_compaction = true` on if you have steady compaction load. The read flag is worth turning on too if cache pressure is hurting your P99.9 / P99.99.

## Reproducing the benchmark

```bash
docker build -f examples/Dockerfile.bench -t lsm-tree-bench:latest .
bash examples/run_bench.sh
```

All knobs are env vars; see the top of `examples/run_bench.sh` and `examples/DIRECT_IO_BENCH.md`.

Refs: facebook/rocksdb#14743


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional direct I/O toggles for compaction reads and for flush/compaction outputs with platform-specific implementations (Linux/macOS/fallback).

* **Documentation**
  * README documents the Optional direct I/O behavior and adds a reference footnote.
  * Added a reproducible benchmark guide and Docker-based benchmark artifacts with recommended configs and interpreted results.

* **Bug Fixes**
  * Corrected checksum finalization to match actual bytes written.

* **Tests**
  * New unit and integration tests exercising direct I/O permutations, fallbacks, and benchmark value generation.

* **Chores**
  * Updated ignore rules and added a build-time dependency declaration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
