### PR TITLE
use the SuperVersion seqno for get_highest_persisted_seqno if the tree is totally empty

### DIFF
--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -612,9 +612,11 @@ fn drop_tables(
         |current| {
             let mut copy = current.clone();
 
-            copy.version = copy
-                .version
-                .with_dropped(ids_to_drop, &mut dropped_blob_files)?;
+            copy.version = copy.version.with_dropped_at(
+                ids_to_drop,
+                &mut dropped_blob_files,
+                Some(opts.global_seqno.get()),
+            )?;
 
             Ok(copy)
         },

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -73,13 +73,14 @@ pub struct TreeInner {
 
 impl TreeInner {
     pub(crate) fn create_new(config: Config) -> crate::Result<Self> {
-        let version = Version::new(
+        let version = Version::new_at_seqno(
             0,
             if config.kv_separation_opts.is_some() {
                 crate::TreeType::Blob
             } else {
                 crate::TreeType::Standard
             },
+            Some(config.seqno.get()),
         );
         persist_version(&config.path, &version)?;
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -271,7 +271,11 @@ impl AbstractTree for Tree {
                 let mut copy = v.clone();
                 copy.active_memtable = Arc::new(Memtable::new(self.memtable_id_counter.next()));
                 copy.sealed_memtables = Arc::default();
-                copy.version = Version::new(v.version.id() + 1, self.tree_type());
+                copy.version = Version::new_at_seqno(
+                    v.version.id() + 1,
+                    self.tree_type(),
+                    Some(config.seqno.get()),
+                );
                 Ok(copy)
             },
             &config.seqno,
@@ -630,10 +634,17 @@ impl AbstractTree for Tree {
     }
 
     fn get_highest_persisted_seqno(&self) -> Option<SeqNo> {
-        self.current_version()
-            .iter_tables()
-            .map(Table::get_highest_seqno)
-            .max()
+        let guard = self.version_history.read().expect("lock is poisoned");
+        let super_version = guard.latest_version();
+        if super_version.is_empty() {
+            super_version.version.created_seqno
+        } else {
+            super_version
+                .version
+                .iter_tables()
+                .map(Table::get_highest_seqno)
+                .max()
+        }
     }
 
     fn get<K: AsRef<[u8]>>(&self, key: K, seqno: SeqNo) -> crate::Result<Option<UserValue>> {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -634,8 +634,12 @@ impl AbstractTree for Tree {
     }
 
     fn get_highest_persisted_seqno(&self) -> Option<SeqNo> {
-        let guard = self.version_history.read().expect("lock is poisoned");
-        let super_version = guard.latest_version();
+        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
+        let super_version = self
+            .version_history
+            .read()
+            .expect("lock is poisoned")
+            .latest_version();
         if super_version.is_empty() {
             super_version.version.created_seqno
         } else {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -19,11 +19,11 @@ use crate::checksum::ChecksumType;
 use crate::coding::Encode;
 use crate::compaction::state::hidden_set::HiddenSet;
 use crate::version::recovery::Recovery;
-use crate::TreeType;
 use crate::{
     vlog::{BlobFile, BlobFileId},
     HashSet, KeyRange, Table, TableId,
 };
+use crate::{SeqNo, TreeType};
 use optimize::optimize_runs;
 use run::Ranged;
 use std::{ops::Deref, sync::Arc};
@@ -158,6 +158,9 @@ pub struct VersionInner {
 
     /// Blob file fragmentation
     gc_stats: Arc<FragmentationMap>,
+
+    /// seqno at which this version was born
+    pub created_seqno: Option<SeqNo>,
 }
 
 /// A version is an immutable, point-in-time view of a tree's structure
@@ -209,6 +212,11 @@ impl Version {
 
     /// Creates a new empty version.
     pub fn new(id: VersionId, tree_type: TreeType) -> Self {
+        Self::new_at_seqno(id, tree_type, None)
+    }
+
+    /// Creates a new empty version at the given sequence number
+    pub fn new_at_seqno(id: VersionId, tree_type: TreeType, created_seqno: Option<SeqNo>) -> Self {
         let levels = (0..DEFAULT_LEVEL_COUNT).map(|_| Level::empty()).collect();
 
         Self {
@@ -218,6 +226,7 @@ impl Version {
                 levels,
                 blob_files: Arc::default(),
                 gc_stats: Arc::default(),
+                created_seqno,
             }),
         }
     }
@@ -265,6 +274,7 @@ impl Version {
             version_levels,
             BlobFileList::new(blob_files.iter().cloned().map(|bf| (bf.id(), bf)).collect()),
             recovery.gc_stats,
+            recovery.created_seqno,
         ))
     }
 
@@ -275,6 +285,7 @@ impl Version {
         levels: Vec<Level>,
         blob_files: BlobFileList,
         gc_stats: FragmentationMap,
+        created_seqno: Option<SeqNo>,
     ) -> Self {
         Self {
             inner: Arc::new(VersionInner {
@@ -283,6 +294,7 @@ impl Version {
                 levels,
                 blob_files: Arc::new(blob_files),
                 gc_stats: Arc::new(gc_stats),
+                created_seqno,
             }),
         }
     }
@@ -391,6 +403,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
+                created_seqno: self.created_seqno,
             }),
         }
     }
@@ -475,6 +488,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
+                created_seqno: self.created_seqno,
             }),
         })
     }
@@ -556,6 +570,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
+                created_seqno: self.created_seqno,
             }),
         }
     }
@@ -604,6 +619,7 @@ impl Version {
                 levels,
                 blob_files: self.blob_files.clone(),
                 gc_stats: self.gc_stats.clone(),
+                created_seqno: self.created_seqno,
             }),
         }
     }
@@ -698,6 +714,11 @@ impl Version {
         writer.start("blob_gc_stats")?;
 
         self.gc_stats.encode_into(writer)?;
+
+        if let Some(seqno) = self.created_seqno {
+            writer.start("created_seqno")?;
+            writer.write_u64::<LittleEndian>(seqno)?;
+        }
 
         Ok(())
     }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -159,7 +159,10 @@ pub struct VersionInner {
     /// Blob file fragmentation
     gc_stats: Arc<FragmentationMap>,
 
-    /// seqno at which this version was born
+    /// Seqno at which this version was created.
+    ///
+    /// Note: This is optional because previous versions of `lsm-tree` did not persist the version
+    /// seqno.
     pub created_seqno: Option<SeqNo>,
 }
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -419,6 +419,18 @@ impl Version {
         ids: &[TableId],
         dropped_blob_files: &mut Vec<BlobFile>,
     ) -> crate::Result<Self> {
+        self.with_dropped_at(ids, dropped_blob_files, None)
+    }
+
+    /// Returns a new version with a list of tables removed, as of a given sequence number.
+    ///
+    /// The table files are not immediately deleted, this is handled by the version system's free list.
+    pub fn with_dropped_at(
+        &self,
+        ids: &[TableId],
+        dropped_blob_files: &mut Vec<BlobFile>,
+        seqno: Option<SeqNo>,
+    ) -> crate::Result<Self> {
         let id = self.id + 1;
 
         let mut levels = vec![];
@@ -484,6 +496,14 @@ impl Version {
             Arc::new(copy)
         };
 
+        // reset the created_seqno if the tree has newly become empty
+        let table_count: usize = levels.iter().map(|x| x.table_count()).sum();
+        let created_seqno = if table_count == 0 {
+            self.created_seqno.max(seqno)
+        } else {
+            self.created_seqno
+        };
+
         Ok(Self {
             inner: Arc::new(VersionInner {
                 id,
@@ -491,7 +511,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
-                created_seqno: self.created_seqno,
+                created_seqno,
             }),
         })
     }
@@ -504,6 +524,27 @@ impl Version {
         diff: Option<FragmentationMap>,
         new_blob_files: Vec<BlobFile>,
         blob_files_to_drop: &HashSet<BlobFileId>,
+    ) -> Self {
+        self.with_merge_at(
+            old_ids,
+            new_tables,
+            dest_level,
+            diff,
+            new_blob_files,
+            blob_files_to_drop,
+            None,
+        )
+    }
+
+    pub fn with_merge_at(
+        &self,
+        old_ids: &[TableId],
+        new_tables: &[Table],
+        dest_level: usize,
+        diff: Option<FragmentationMap>,
+        new_blob_files: Vec<BlobFile>,
+        blob_files_to_drop: &HashSet<BlobFileId>,
+        seqno: Option<SeqNo>,
     ) -> Self {
         let id = self.id + 1;
 
@@ -566,6 +607,14 @@ impl Version {
             self.gc_stats.clone()
         };
 
+        // reset the created_seqno if the tree has newly become empty
+        let table_count: usize = levels.iter().map(|x| x.table_count()).sum();
+        let created_seqno = if table_count == 0 {
+            self.created_seqno.max(seqno)
+        } else {
+            self.created_seqno
+        };
+
         Self {
             inner: Arc::new(VersionInner {
                 id,
@@ -573,7 +622,7 @@ impl Version {
                 levels,
                 blob_files: value_log,
                 gc_stats,
-                created_seqno: self.created_seqno,
+                created_seqno,
             }),
         }
     }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -536,6 +536,7 @@ impl Version {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn with_merge_at(
         &self,
         old_ids: &[TableId],

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -29,6 +29,7 @@ pub struct Recovery {
     pub table_ids: Vec<Vec<Vec<RecoveredTable>>>,
     pub blob_file_ids: Vec<(BlobFileId, Checksum)>,
     pub gc_stats: crate::blob_tree::FragmentationMap,
+    pub created_seqno: Option<SeqNo>,
 }
 
 pub fn recover(folder: &Path) -> crate::Result<Recovery> {
@@ -139,6 +140,13 @@ pub fn recover(folder: &Path) -> crate::Result<Recovery> {
         crate::blob_tree::FragmentationMap::decode_from(&mut reader)?
     };
 
+    let created_seqno = if let Some(section) = toc.section(b"created_seqno") {
+        let mut reader = section.buf_reader(&version_file_path)?;
+        Some(reader.read_u64::<LittleEndian>()?)
+    } else {
+        None
+    };
+
     Ok(Recovery {
         tree_type: {
             let byte = toc.section(b"tree_type").ok_or(crate::Error::Unrecoverable)
@@ -156,5 +164,6 @@ pub fn recover(folder: &Path) -> crate::Result<Recovery> {
         table_ids: levels,
         blob_file_ids,
         gc_stats,
+        created_seqno,
     })
 }

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -26,6 +26,14 @@ pub struct SuperVersion {
     pub(crate) seqno: SeqNo,
 }
 
+impl SuperVersion {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.active_memtable.is_empty()
+            && self.sealed_memtables.iter().all(|t| t.is_empty())
+            && self.version.table_count() == 0
+    }
+}
+
 pub struct SuperVersions(VecDeque<SuperVersion>);
 
 impl SuperVersions {

--- a/tests/tree_clear.rs
+++ b/tests/tree_clear.rs
@@ -10,6 +10,8 @@ fn tree_clear() -> lsm_tree::Result<()> {
 
     let tree = Config::new(&folder, seqno.clone(), visible_seqno.clone()).open()?;
 
+    assert_eq!(tree.get_highest_persisted_seqno(), Some(0));
+
     assert_eq!(0, tree.len(visible_seqno.get(), None)?);
 
     {
@@ -17,6 +19,7 @@ fn tree_clear() -> lsm_tree::Result<()> {
         tree.insert("a", "a", seqno);
         visible_seqno.fetch_max(seqno + 1);
     }
+    assert_eq!(tree.get_highest_persisted_seqno(), None);
 
     assert!(tree.contains_key("a", SeqNo::MAX)?);
     assert_eq!(1, tree.len(visible_seqno.get(), None)?);
@@ -24,6 +27,7 @@ fn tree_clear() -> lsm_tree::Result<()> {
     tree.clear()?;
     assert!(!tree.contains_key("a", SeqNo::MAX)?);
     assert_eq!(0, tree.len(visible_seqno.get(), None)?);
+    assert!(tree.get_highest_persisted_seqno().is_some());
 
     {
         let seqno = seqno.next();
@@ -38,6 +42,12 @@ fn tree_clear() -> lsm_tree::Result<()> {
     tree.clear()?;
     assert!(!tree.contains_key("a", SeqNo::MAX)?);
     assert_eq!(0, tree.len(visible_seqno.get(), None)?);
+    let previous = tree.get_highest_persisted_seqno();
+    assert!(previous.is_some());
+
+    // re-open the tree to ensure that the seqno is persisted
+    let tree = Config::new(&folder, seqno.clone(), visible_seqno.clone()).open()?;
+    assert_eq!(tree.get_highest_persisted_seqno(), previous);
 
     Ok(())
 }

--- a/tests/tree_seqno.rs
+++ b/tests/tree_seqno.rs
@@ -11,9 +11,11 @@ fn tree_highest_seqno() -> lsm_tree::Result<()> {
         SequenceNumberCounter::default(),
     )
     .open()?;
-    assert_eq!(tree.get_highest_seqno(), None);
+    // There's no data in this tree, but the actual tree metadata
+    // has been persisted, so its seqno is reported as 0
+    assert_eq!(tree.get_highest_seqno(), Some(0));
     assert_eq!(tree.get_highest_memtable_seqno(), None);
-    assert_eq!(tree.get_highest_persisted_seqno(), None);
+    assert_eq!(tree.get_highest_persisted_seqno(), Some(0));
 
     tree.insert("a", "a0", 0);
     assert_eq!(tree.get_highest_seqno(), Some(0));


### PR DESCRIPTION
I talked to @marvin-j97  in discord and they suggest that this would be a simpler/better alternative to #291.

If a tree is totally empty (no tables on disk, nothing in the memtables; e.g., the state right after a clear), then we use the seqno of the SuperVersion as the highest persisted seqno.

I believe that this will fix fjall-rs/fjall#288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable tracking of a tree's highest persisted sequence number so open, insert, clear, and reopen report consistent persisted-seqno state.

* **New Features**
  * Trees now record and restore an optional creation seqno and initialize from the configured start seqno.
  * Drop/compaction now records explicit seqno markers for persisted history.

* **Tests**
  * Strengthened tests validating persisted-seqno transitions across insert, clear, persist, and reopen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->