### PR TITLE
Make `Slice` derive `Default`

### DIFF
--- a/src/slice/slice_bytes/mod.rs
+++ b/src/slice/slice_bytes/mod.rs
@@ -28,7 +28,7 @@ impl Slice {
     #[doc(hidden)]
     #[must_use]
     pub fn empty() -> Self {
-        Self(Bytes::from_static(&[]))
+        Self::default()
     }
 
     #[doc(hidden)]

--- a/src/slice/slice_bytes/mod.rs
+++ b/src/slice/slice_bytes/mod.rs
@@ -9,7 +9,7 @@ pub use bytes::BytesMut as Builder;
 /// An immutable byte slice that can be cloned without additional heap allocation
 ///
 /// There is no guarantee of any sort of alignment for zero-copy (de)serialization.
-#[derive(Debug, Clone, Eq, Hash, Ord)]
+#[derive(Debug, Default, Clone, Eq, Hash, Ord)]
 pub struct Slice(pub(super) Bytes);
 
 impl Slice {

--- a/src/slice/slice_default/mod.rs
+++ b/src/slice/slice_default/mod.rs
@@ -9,7 +9,7 @@ pub use byteview::Builder;
 /// An immutable byte slice that can be cloned without additional heap allocation
 ///
 /// There is no guarantee of any sort of alignment for zero-copy (de)serialization.
-#[derive(Debug, Clone, Eq, Hash, Ord)]
+#[derive(Debug, Default, Clone, Eq, Hash, Ord)]
 pub struct Slice(pub(super) ByteView);
 
 impl Slice {

--- a/src/slice/slice_default/mod.rs
+++ b/src/slice/slice_default/mod.rs
@@ -28,7 +28,7 @@ impl Slice {
     #[doc(hidden)]
     #[must_use]
     pub fn empty() -> Self {
-        Self(ByteView::new(&[]))
+        Self::default()
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
This would be useful for me and I don't see why not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Slice` now implements the `Default` trait, enabling empty slices to be created via `Slice::default()` for more idiomatic Rust code and improved API consistency with standard library conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->