### PR TITLE
fix: persist correct compression type for relocated blob files

### DIFF
--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -84,6 +84,7 @@ impl MultiWriter {
     pub(crate) fn use_passthrough_compression(mut self, compression: CompressionType) -> Self {
         assert_eq!(self.compression, CompressionType::None);
         self.passthrough_compression = compression;
+        self.active_writer.passthrough_compression = compression;
         self
     }
 
@@ -104,14 +105,11 @@ impl MultiWriter {
         let blob_file_path = self.folder.join(new_blob_file_id.to_string());
 
         let new_writer = Writer::new(blob_file_path, new_blob_file_id, self.tree_id)?
-            .use_compression(self.compression);
+            .use_compression(self.compression)
+            .use_passthrough_compression(self.passthrough_compression);
 
         let old_writer = std::mem::replace(&mut self.active_writer, new_writer);
-        let blob_file = Self::consume_writer(
-            old_writer,
-            self.passthrough_compression,
-            self.descriptor_table.clone(),
-        )?;
+        let blob_file = Self::consume_writer(old_writer, self.descriptor_table.clone())?;
         self.results.extend(blob_file);
 
         Ok(())
@@ -119,7 +117,6 @@ impl MultiWriter {
 
     fn consume_writer(
         writer: Writer,
-        passthrough_compression: CompressionType,
         descriptor_table: Option<Arc<DescriptorTable>>,
     ) -> crate::Result<Option<BlobFile>> {
         if writer.item_count > 0 {
@@ -156,12 +153,7 @@ impl MultiWriter {
                     total_compressed_bytes: metadata.total_compressed_bytes,
                     total_uncompressed_bytes: metadata.total_uncompressed_bytes,
                     key_range: metadata.key_range.clone(),
-
-                    compression: if passthrough_compression == CompressionType::None {
-                        metadata.compression
-                    } else {
-                        passthrough_compression
-                    },
+                    compression: metadata.compression,
                 },
             }));
 
@@ -243,11 +235,7 @@ impl MultiWriter {
     }
 
     pub(crate) fn finish(mut self) -> crate::Result<Vec<BlobFile>> {
-        let blob_file = Self::consume_writer(
-            self.active_writer,
-            self.passthrough_compression,
-            self.descriptor_table.clone(),
-        )?;
+        let blob_file = Self::consume_writer(self.active_writer, self.descriptor_table.clone())?;
         self.results.extend(blob_file);
         Ok(self.results)
     }

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -42,6 +42,7 @@ pub struct Writer {
     pub(crate) last_key: Option<UserKey>,
 
     pub(crate) compression: CompressionType,
+    pub(crate) passthrough_compression: CompressionType,
 }
 
 impl Writer {
@@ -79,11 +80,17 @@ impl Writer {
             last_key: None,
 
             compression: CompressionType::None,
+            passthrough_compression: CompressionType::None,
         })
     }
 
     pub fn use_compression(mut self, compressor: CompressionType) -> Self {
         self.compression = compressor;
+        self
+    }
+
+    pub(crate) fn use_passthrough_compression(mut self, compressor: CompressionType) -> Self {
+        self.passthrough_compression = compressor;
         self
     }
 
@@ -223,7 +230,11 @@ impl Writer {
                     .clone()
                     .expect("should have written at least 1 item"),
             )),
-            compression: self.compression,
+            compression: if self.passthrough_compression == CompressionType::None {
+                self.compression
+            } else {
+                self.passthrough_compression
+            },
         };
         metadata.encode_into(&mut self.writer)?;
 

--- a/tests/blob_major_compact_relocation_recovery.rs
+++ b/tests/blob_major_compact_relocation_recovery.rs
@@ -1,0 +1,65 @@
+#[test_log::test]
+#[cfg(feature = "lz4")]
+fn blob_tree_major_compact_relocation_recovery() -> lsm_tree::Result<()> {
+    use lsm_tree::{
+        get_tmp_folder, AbstractTree, KvSeparationOptions, SeqNo, SequenceNumberCounter,
+    };
+
+    let folder = get_tmp_folder();
+    let path = folder.path();
+
+    let big_value = b"neptune!".repeat(4_096);
+
+    {
+        let tree = lsm_tree::Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(
+            KvSeparationOptions::default()
+                .compression(lsm_tree::CompressionType::Lz4)
+                .separation_threshold(1)
+                .staleness_threshold(0.0000001)
+                .age_cutoff(1.0),
+        ))
+        .open()?;
+
+        tree.insert("a", &big_value, 0);
+        tree.insert("b", b"smol", 0);
+        tree.flush_active_memtable(0)?;
+        assert_eq!(1, tree.table_count());
+        assert_eq!(1, tree.blob_file_count());
+
+        tree.remove("b", 1);
+        tree.flush_active_memtable(0)?;
+
+        tree.major_compact(u64::MAX, 1_000)?;
+        tree.major_compact(u64::MAX, 1_000)?;
+        assert_eq!(1, tree.blob_file_count());
+
+        {
+            let gc_stats = tree.current_version().gc_stats().clone();
+
+            assert_eq!(&lsm_tree::HashMap::default(), &*gc_stats);
+        }
+
+        let value = tree.get("a", SeqNo::MAX)?.unwrap();
+        assert_eq!(&*value, big_value);
+    }
+
+    {
+        let tree = lsm_tree::Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(Default::default()))
+        .open()?;
+
+        let value = tree.get("a", SeqNo::MAX)?.unwrap();
+        assert_eq!(&*value, big_value);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Blob files written during blob relocation stored CompressionType::None in their meta block, so compressed blobs were returned without decompression after recovery.

Fixes https://github.com/fjall-rs/lsm-tree/issues/300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blob compression handling so stored data now preserves the expected compression settings through rotation and file finalization.
  * Fixed recovery behavior around major compaction, helping ensure values remain accessible after blob relocation and reopen.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->