### PR TITLE
Race: check sealed ids

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -91,6 +91,8 @@ pub trait AbstractTree {
             .map(|mt| mt.id)
             .collect::<Vec<_>>();
 
+        log::debug!("Flushing sealed memtables {sealed_ids:?} to table(s)");
+
         let flushed_size = latest.sealed_memtables.iter().map(|mt| mt.size()).sum();
 
         let merger = Merger::new(

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -450,6 +450,15 @@ impl AbstractTree for Tree {
         #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         let mut version_lock = self.version_history.write().expect("lock is poisoned");
 
+        // NOTE: Check for race condition
+        if sealed_memtables_to_delete
+            .iter()
+            .any(|id| !version_lock.latest_version().sealed_memtables.contains(id))
+        {
+            log::debug!("Not registering tables because flush task processed some sealed memtables which do not exist (anymore)");
+            return Ok(());
+        }
+
         version_lock.upgrade_version(
             &self.config.path,
             |current| {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -451,6 +451,7 @@ impl AbstractTree for Tree {
         let mut version_lock = self.version_history.write().expect("lock is poisoned");
 
         // NOTE: Check for race condition
+        // Fixes: https://github.com/fjall-rs/fjall/issues/287#issuecomment-4938188362
         if sealed_memtables_to_delete
             .iter()
             .any(|id| !version_lock.latest_version().sealed_memtables.contains(id))

--- a/src/tree/sealed.rs
+++ b/src/tree/sealed.rs
@@ -34,4 +34,8 @@ impl SealedMemtables {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+
+    pub fn contains(&self, id: &MemtableId) -> bool {
+        self.0.iter().any(|t| t.id() == *id)
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent flush operations to prevent redundant maintenance work.
  * Added safeguards that avoid processing sealed memtables that have already been handled.
* **Diagnostics**
  * Added debug logging to improve visibility into memtable flushing and concurrent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->