### PR TITLE
fix: retry transient file errors on Windows

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -58,6 +58,56 @@ pub fn read_exact(file: &File, offset: u64, size: usize) -> std::io::Result<Slic
     Ok(builder.freeze().into())
 }
 
+/// Runs an I/O operation, retrying transient Windows errors with backoff.
+///
+/// External programs (antivirus, indexers, backup agents) may briefly hold files open
+/// without sharing flags on Windows, failing renames and deletes that would succeed a
+/// moment later; POSIX has no such failure mode, so elsewhere the operation runs once.
+pub fn retry_transient_io<T>(mut op: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+    #[cfg(windows)]
+    {
+        const MAX_ATTEMPTS: u32 = 10;
+
+        let mut delay = std::time::Duration::from_millis(1);
+
+        for _ in 1..MAX_ATTEMPTS {
+            match op() {
+                Err(e) if is_transient_windows_error(&e) => {
+                    std::thread::sleep(delay);
+                    delay *= 2;
+                }
+                result => return result,
+            }
+        }
+    }
+
+    op()
+}
+
+#[cfg(windows)]
+fn is_transient_windows_error(e: &std::io::Error) -> bool {
+    // ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION, ERROR_LOCK_VIOLATION, ERROR_USER_MAPPED_FILE
+    matches!(e.raw_os_error(), Some(5 | 32 | 33 | 1224))
+}
+
+/// Persists a named temporary file to its final path, replacing any existing file.
+pub fn persist_temp_file(temp_file: tempfile::NamedTempFile, path: &Path) -> std::io::Result<()> {
+    let mut temp_file = Some(temp_file);
+
+    retry_transient_io(|| {
+        #[expect(clippy::expect_used, reason = "the temp file is put back on failure")]
+        temp_file
+            .take()
+            .expect("temp file should be present")
+            .persist(path)
+            .map(|_| ())
+            .map_err(|e| {
+                temp_file = Some(e.file);
+                e.error
+            })
+    })
+}
+
 /// Atomically rewrites a file.
 pub fn rewrite_atomic(path: &Path, content: &[u8]) -> std::io::Result<()> {
     #[expect(
@@ -70,7 +120,7 @@ pub fn rewrite_atomic(path: &Path, content: &[u8]) -> std::io::Result<()> {
     temp_file.write_all(content)?;
     temp_file.flush()?;
     temp_file.as_file_mut().sync_all()?;
-    temp_file.persist(path)?;
+    persist_temp_file(temp_file, path)?;
 
     // TODO: not sure why it fails on Windows...
     #[cfg(not(target_os = "windows"))]
@@ -125,5 +175,58 @@ mod tests {
         assert_eq!("newcontent", content);
 
         Ok(())
+    }
+
+    #[test]
+    fn persist_temp_file_replaces_existing() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let path = dir.path().join("test.txt");
+        std::fs::write(&path, b"old")?;
+
+        let mut temp_file = tempfile::NamedTempFile::new_in(dir.path())?;
+        write!(temp_file, "new")?;
+        persist_temp_file(temp_file, &path)?;
+
+        let content = std::fs::read_to_string(&path)?;
+        assert_eq!("new", content);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn retry_transient_io_retries_sharing_violation() {
+        let mut attempts = 0;
+
+        let result = retry_transient_io(|| {
+            attempts += 1;
+
+            if attempts < 3 {
+                // ERROR_SHARING_VIOLATION
+                Err(std::io::Error::from_raw_os_error(32))
+            } else {
+                Ok(42)
+            }
+        });
+
+        assert!(matches!(result, Ok(42)));
+        assert_eq!(3, attempts);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn retry_transient_io_fails_fast_on_other_errors() {
+        let mut attempts = 0;
+
+        let result: std::io::Result<()> = retry_transient_io(|| {
+            attempts += 1;
+
+            // ERROR_FILE_NOT_FOUND
+            Err(std::io::Error::from_raw_os_error(2))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(1, attempts);
     }
 }

--- a/src/version/persist.rs
+++ b/src/version/persist.rs
@@ -1,10 +1,13 @@
 use crate::{
     checksum::ChecksummedWriter,
-    file::{fsync_directory, rewrite_atomic, CURRENT_VERSION_FILE},
+    file::{fsync_directory, retry_transient_io, rewrite_atomic, CURRENT_VERSION_FILE},
     version::Version,
 };
 use byteorder::{LittleEndian, WriteBytesExt};
-use std::{io::BufWriter, path::Path};
+use std::{
+    io::{BufWriter, Write},
+    path::Path,
+};
 
 pub fn persist_version(folder: &Path, version: &Version) -> crate::Result<()> {
     log::trace!(
@@ -14,8 +17,8 @@ pub fn persist_version(folder: &Path, version: &Version) -> crate::Result<()> {
     );
 
     let path = folder.join(format!("v{}", version.id()));
-    let file = std::fs::File::create_new(path)?;
-    let writer = BufWriter::new(file);
+    let file = retry_transient_io(|| std::fs::File::create(&path))?;
+    let writer = BufWriter::new(&file);
     let mut writer = ChecksummedWriter::new(writer);
 
     {
@@ -27,12 +30,18 @@ pub fn persist_version(folder: &Path, version: &Version) -> crate::Result<()> {
             sfa::Error::Io(e) => crate::Error::from(e),
             _ => unreachable!(),
         })?;
-
-        // IMPORTANT: fsync folder on Unix
-        fsync_directory(folder)?;
     }
 
+    writer.flush()?;
+
     let checksum = writer.checksum();
+
+    drop(writer);
+
+    file.sync_all()?;
+
+    // IMPORTANT: fsync folder on Unix
+    fsync_directory(folder)?;
 
     let mut current_file_content = vec![];
     current_file_content.write_u64::<LittleEndian>(version.id())?;
@@ -42,4 +51,30 @@ pub fn persist_version(folder: &Path, version: &Version) -> crate::Result<()> {
     rewrite_atomic(&folder.join(CURRENT_VERSION_FILE), &current_file_content)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TreeType;
+    use test_log::test;
+
+    #[test]
+    fn version_persist_replaces_orphaned_file() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let version = Version::new(0, TreeType::Standard);
+
+        // Simulates the leftover of a persist that failed midway
+        std::fs::write(dir.path().join("v0"), b"partial")?;
+
+        persist_version(dir.path(), &version)?;
+
+        assert_ne!(
+            b"partial".as_slice(),
+            &*std::fs::read(dir.path().join("v0"))?
+        );
+        assert!(dir.path().join(CURRENT_VERSION_FILE).try_exists()?);
+
+        Ok(())
+    }
 }

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -92,7 +92,7 @@ impl SuperVersions {
 
                 let path = folder.join(format!("v{}", head.version.id()));
                 if path.try_exists()? {
-                    std::fs::remove_file(path)?;
+                    crate::file::retry_transient_io(|| std::fs::remove_file(&path))?;
                 }
 
                 self.0.pop_front();


### PR DESCRIPTION
External tools briefly holding files open can fail renames and deletes in the compaction worker, poisoning the database. Retry with backoff, the same approach RocksDB uses on Windows. Version manifests are also written to a temp file and renamed into place now, so a failed persist leaves no partial file behind to collide with the next one.

Fixes https://github.com/fjall-rs/lsm-tree/issues/304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows reliability for atomic file updates by retrying transient sharing/locking-related I/O failures with exponential backoff.
  * Strengthened version file persistence by using a safer temp-file finalization flow and ensuring data is fully flushed and synced before publishing.
  * Version files now correctly replace any existing or partial destination artifacts after persistence.
  * Maintenance cleanup now retries transient failures when removing outdated version files, improving robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->