### PR TITLE
fix(fifo): use Lmax as canonical level

### DIFF
--- a/src/compaction/fifo.rs
+++ b/src/compaction/fifo.rs
@@ -191,7 +191,9 @@ impl CompactionStrategy for Strategy {
 mod tests {
     use super::Strategy;
     use crate::{AbstractTree, Config, KvSeparationOptions, SequenceNumberCounter};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+
+    static TIME_OVERRIDE_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn fifo_empty_levels() -> crate::Result<()> {
@@ -211,19 +213,21 @@ mod tests {
     }
 
     #[test]
-    fn fifo_zero_level_config_is_noop() -> crate::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let mut config = Config::new(
-            dir.path(),
-            SequenceNumberCounter::default(),
-            SequenceNumberCounter::default(),
-        );
-        config.level_count = 0;
-        let tree = config.open()?;
+    fn fifo_invalid_level_config_is_noop() -> crate::Result<()> {
+        for level_count in [0, 8] {
+            let dir = tempfile::tempdir()?;
+            let mut config = Config::new(
+                dir.path(),
+                SequenceNumberCounter::default(),
+                SequenceNumberCounter::default(),
+            );
+            config.level_count = level_count;
+            let tree = config.open()?;
 
-        tree.compact(Arc::new(Strategy::new(1, None)), 0)?;
+            tree.compact(Arc::new(Strategy::new(1, None)), 0)?;
 
-        assert_eq!(0, tree.table_count());
+            assert_eq!(0, tree.table_count());
+        }
         Ok(())
     }
 
@@ -302,6 +306,9 @@ mod tests {
 
     #[test]
     fn fifo_ttl() -> crate::Result<()> {
+        let _time_lock = TIME_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempfile::tempdir()?;
         let tree = Config::new(
             dir.path(),
@@ -338,6 +345,9 @@ mod tests {
 
     #[test]
     fn fifo_ttl_then_limit_additional_drops_blob_unit() -> crate::Result<()> {
+        let _time_lock = TIME_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempfile::tempdir()?;
         let tree = Config::new(
             dir.path(),
@@ -347,16 +357,18 @@ mod tests {
         .with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
         .open()?;
 
-        // Create two tables; we will expire them via time override and force additional drops via limit.
+        crate::time::set_unix_timestamp_for_test(Some(std::time::Duration::from_secs(1_000)));
         tree.insert("a", "$", 0);
         tree.flush_active_memtable(0)?;
+
+        crate::time::set_unix_timestamp_for_test(Some(std::time::Duration::from_secs(1_005)));
         tree.insert("b", "$", 1);
         tree.flush_active_memtable(1)?;
 
-        crate::time::set_unix_timestamp_for_test(Some(std::time::Duration::from_secs(10_000_000)));
+        crate::time::set_unix_timestamp_for_test(Some(std::time::Duration::from_secs(1_011)));
 
-        // TTL=1s will mark both expired; very small limit ensures size-based collection path is also exercised.
-        let fifo = Arc::new(Strategy::new(1, Some(1)));
+        // TTL drops the first table; the small limit drops the second.
+        let fifo = Arc::new(Strategy::new(1, Some(10)));
         tree.compact(fifo.clone(), 2)?;
         tree.compact(fifo, 2)?;
 

--- a/src/compaction/fifo.rs
+++ b/src/compaction/fifo.rs
@@ -2,10 +2,10 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
-use super::{Choice, CompactionStrategy};
+use super::{Choice, CompactionStrategy, Input as CompactionInput};
 use crate::{
-    compaction::state::CompactionState, config::Config, time::unix_timestamp, version::Version,
-    HashSet, KvPair,
+    compaction::state::CompactionState, config::Config, table::Table, time::unix_timestamp,
+    version::Version, HashSet, KvPair,
 };
 
 #[doc(hidden)]
@@ -16,8 +16,8 @@ pub const NAME: &str = "FifoCompaction";
 /// Limits the tree size to roughly `limit` bytes, deleting the oldest table(s)
 /// when the threshold is reached.
 ///
-/// Will also merge tables if the number of tables in level 0 grows too much, which
-/// could cause write stalls.
+/// Newly flushed tables are moved from level 0 into the last level, and merged
+/// with overlapping tables when necessary.
 ///
 /// Additionally, a (lazy) TTL can be configured to drop old tables.
 ///
@@ -71,23 +71,58 @@ impl CompactionStrategy for Strategy {
         ]
     }
 
-    fn choose(&self, version: &Version, _: &Config, state: &CompactionState) -> Choice {
+    fn choose(&self, version: &Version, config: &Config, state: &CompactionState) -> Choice {
         let first_level = version.l0();
+        let last_level_idx = config.level_count - 1;
+
+        let Some(last_level) = version.level(usize::from(last_level_idx)) else {
+            return Choice::DoNothing;
+        };
+
+        if !first_level.is_empty() {
+            if version.level_is_busy(0, state.hidden_set())
+                || version.level_is_busy(usize::from(last_level_idx), state.hidden_set())
+            {
+                return Choice::DoNothing;
+            }
+
+            assert!(first_level.is_disjoint(), "L0 needs to be disjoint");
+
+            let mut table_ids = first_level.list_ids();
+            let key_range = first_level.aggregate_key_range();
+            let overlapping_table_ids: Vec<_> = last_level
+                .iter()
+                .flat_map(|run| run.get_overlapping(&key_range))
+                .map(Table::id)
+                .collect();
+
+            table_ids.extend(&overlapping_table_ids);
+
+            let input = CompactionInput {
+                table_ids,
+                dest_level: last_level_idx,
+                canonical_level: last_level_idx,
+                target_size: u64::MAX,
+            };
+
+            return if overlapping_table_ids.is_empty() {
+                Choice::Move(input)
+            } else {
+                Choice::Merge(input)
+            };
+        }
 
         // Early return avoids unnecessary work and keeps FIFO a no-op when there is nothing to do.
-        if first_level.is_empty() {
+        if last_level.is_empty()
+            || version.level_is_busy(usize::from(last_level_idx), state.hidden_set())
+        {
             return Choice::DoNothing;
         }
 
-        assert!(first_level.is_disjoint(), "L0 needs to be disjoint");
-
-        assert!(
-            !version.level_is_busy(0, state.hidden_set()),
-            "FIFO compaction never compacts",
-        );
+        assert!(last_level.is_disjoint(), "Lmax needs to be disjoint");
 
         // Account for both table file bytes and value-log (blob) bytes to enforce the true space limit.
-        let db_size = first_level.size() + version.blob_files.on_disk_size();
+        let db_size = last_level.size() + version.blob_files.on_disk_size();
 
         let mut ids_to_drop = HashSet::default();
 
@@ -105,7 +140,7 @@ impl CompactionStrategy for Strategy {
         let mut ttl_dropped_bytes = 0u64;
         let mut alive = Vec::new();
 
-        for table in first_level.iter().flat_map(|run| run.iter()) {
+        for table in last_level.iter().flat_map(|run| run.iter()) {
             let expired =
                 ttl_cutoff.is_some_and(|cutoff| u128::from(table.metadata.created_at) <= cutoff);
 
@@ -214,6 +249,7 @@ mod tests {
         let before = tree.table_count();
         // Very small limit forces dropping oldest tables
         let fifo = Arc::new(Strategy::new(1, None));
+        tree.compact(fifo.clone(), 4)?;
         tree.compact(fifo, 4)?;
 
         assert!(tree.table_count() < before);
@@ -238,6 +274,7 @@ mod tests {
 
         let before = tree.table_count();
         let fifo = Arc::new(Strategy::new(1, None));
+        tree.compact(fifo.clone(), 3)?;
         tree.compact(fifo, 3)?;
 
         assert!(tree.table_count() < before);
@@ -270,6 +307,7 @@ mod tests {
         assert_eq!(2, tree.table_count());
 
         let fifo = Arc::new(Strategy::new(u64::MAX, Some(10)));
+        tree.compact(fifo.clone(), 2)?;
         tree.compact(fifo, 2)?;
 
         assert_eq!(1, tree.table_count());
@@ -300,11 +338,95 @@ mod tests {
 
         // TTL=1s will mark both expired; very small limit ensures size-based collection path is also exercised.
         let fifo = Arc::new(Strategy::new(1, Some(1)));
+        tree.compact(fifo.clone(), 2)?;
         tree.compact(fifo, 2)?;
 
         assert_eq!(0, tree.table_count());
 
         crate::time::set_unix_timestamp_for_test(None);
+        Ok(())
+    }
+
+    #[test]
+    fn fifo_drops_from_lmax_after_major_compaction() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        for i in 0..4u8 {
+            tree.insert([b'k', i].as_slice(), "v", u64::from(i));
+            tree.flush_active_memtable(u64::from(i))?;
+        }
+
+        tree.major_compact(u64::MAX, 4)?;
+        let before = tree.table_count();
+        tree.compact(Arc::new(Strategy::new(1, None)), 4)?;
+
+        assert!(tree.table_count() < before);
+        Ok(())
+    }
+
+    #[test]
+    fn fifo_moves_disjoint_l0_tables_to_lmax() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        tree.insert("a", "1", 0);
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(u64::MAX, 0)?;
+
+        tree.insert("b", "2", 1);
+        tree.flush_active_memtable(1)?;
+        tree.compact(Arc::new(Strategy::new(u64::MAX, None)), 1)?;
+
+        let version = tree.current_version();
+        assert!(version.l0().is_empty());
+        assert_eq!(
+            Some(2),
+            version
+                .level(version.level_count() - 1)
+                .map(|level| level.table_count())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn fifo_merges_l0_with_overlapping_lmax_tables() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        tree.insert("a", "1", 0);
+        tree.insert("c", "3", 1);
+        tree.flush_active_memtable(1)?;
+        tree.major_compact(u64::MAX, 1)?;
+
+        tree.insert("b", "2", 2);
+        tree.flush_active_memtable(2)?;
+        tree.compact(Arc::new(Strategy::new(u64::MAX, None)), 2)?;
+
+        let version = tree.current_version();
+        assert!(version.l0().is_empty());
+        assert_eq!(
+            Some(1),
+            version
+                .level(version.level_count() - 1)
+                .map(|level| level.table_count())
+        );
+        assert_eq!(b"2", &*tree.get("b", 3)?.expect("key should exist"));
         Ok(())
     }
 }

--- a/src/compaction/fifo.rs
+++ b/src/compaction/fifo.rs
@@ -104,7 +104,7 @@ impl CompactionStrategy for Strategy {
                 table_ids,
                 dest_level: last_level_idx,
                 canonical_level: last_level_idx,
-                target_size: u64::MAX,
+                target_size: 256 * 1_024 * 1_024,
             };
 
             return if overlapping_table_ids.is_empty() {

--- a/src/compaction/fifo.rs
+++ b/src/compaction/fifo.rs
@@ -73,7 +73,9 @@ impl CompactionStrategy for Strategy {
 
     fn choose(&self, version: &Version, config: &Config, state: &CompactionState) -> Choice {
         let first_level = version.l0();
-        let last_level_idx = config.level_count - 1;
+        let Some(last_level_idx) = config.level_count.checked_sub(1) else {
+            return Choice::DoNothing;
+        };
 
         let Some(last_level) = version.level(usize::from(last_level_idx)) else {
             return Choice::DoNothing;
@@ -203,6 +205,23 @@ mod tests {
 
         let fifo = Arc::new(Strategy::new(1, None));
         tree.compact(fifo, 0)?;
+
+        assert_eq!(0, tree.table_count());
+        Ok(())
+    }
+
+    #[test]
+    fn fifo_zero_level_config_is_noop() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut config = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        );
+        config.level_count = 0;
+        let tree = config.open()?;
+
+        tree.compact(Arc::new(Strategy::new(1, None)), 0)?;
 
         assert_eq!(0, tree.table_count());
         Ok(())
@@ -414,6 +433,7 @@ mod tests {
         tree.flush_active_memtable(1)?;
         tree.major_compact(u64::MAX, 1)?;
 
+        tree.insert("a", "1-updated", 2);
         tree.insert("b", "2", 2);
         tree.flush_active_memtable(2)?;
         tree.compact(Arc::new(Strategy::new(u64::MAX, None)), 2)?;
@@ -427,6 +447,7 @@ mod tests {
                 .map(|level| level.table_count())
         );
         assert_eq!(b"2", &*tree.get("b", 3)?.expect("key should exist"));
+        assert_eq!(b"1-updated", &*tree.get("a", 3)?.expect("key should exist"));
         Ok(())
     }
 }

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -852,8 +852,11 @@ mod tests {
         assert_eq!(3, tree.approximate_len());
         assert_eq!(0, tree.sealed_memtable_count());
 
-        tree.compact(Arc::new(crate::compaction::Fifo::new(1, None)), 3)?;
+        let fifo = Arc::new(crate::compaction::Fifo::new(1, None));
+        tree.compact(fifo.clone(), 3)?;
+        assert_eq!(3, tree.table_count());
 
+        tree.compact(fifo, 3)?;
         assert_eq!(0, tree.table_count());
 
         Ok(())

--- a/tests/blob_fifo_limit.rs
+++ b/tests/blob_fifo_limit.rs
@@ -21,6 +21,7 @@ fn blob_tree_fifo_limit() -> lsm_tree::Result<()> {
         tree.insert(nanoid::nanoid!(), "$", 0);
         tree.flush_active_memtable(0)?;
         tree.compact(compaction.clone(), 0)?;
+        tree.compact(compaction.clone(), 0)?;
         assert!((0..10).contains(&tree.blob_file_count()));
     }
 

--- a/tests/fifo_ttl.rs
+++ b/tests/fifo_ttl.rs
@@ -80,6 +80,7 @@ fn fifo_limit_considers_blob_bytes() -> lsm_tree::Result<()> {
 
     // Very small limit forces dropping based on (table + blob) size
     let fifo = Arc::new(Fifo::new(10, None));
+    tree.compact(fifo.clone(), 3)?;
     tree.compact(fifo, 3)?;
 
     // Should have dropped at least one table due to blob bytes pressure


### PR DESCRIPTION
## What

- Treat Lmax as the canonical FIFO level.
- Move disjoint L0 tables into Lmax without rewriting them.
- Merge L0 with overlapping Lmax tables when a move would violate disjointness.
- Apply FIFO TTL and size drops to Lmax, including after major compaction.

## Why

Major compaction places all tables in Lmax, but FIFO only inspected L0. Once L0 was empty, FIFO became a no-op and could no longer enforce its TTL or size limit.

This keeps L0 as an ingestion level and makes FIFO compaction a two-step process when needed: first move or merge L0 into Lmax, then evaluate drops from Lmax on the next compaction choice.

The separate L0 overlap repair discussed in #310 and #311 remains out of scope; the existing disjoint-L0 invariant is preserved.

Fixes #312.

## Checks

- cargo fmt --all -- --check
- cargo clippy
- cargo test --all-features
- cargo test --doc --features lz4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FIFO compaction so level-0 tables move and merge correctly with final-level tables.
  - Size- and TTL-based cleanup now reliably removes eligible tables.
  - Improved handling of busy or empty levels to avoid unnecessary compaction.
  - Repeated compaction now behaves consistently and helps maintain blob-file counts within configured limits.

- **Tests**
  - Expanded coverage for table movement, overlapping merges, repeated compactions, and FIFO retention limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->