### PR TITLE
test: fuzz optimize_runs visibility

### DIFF
--- a/fuzz/optimize_runs/Cargo.toml
+++ b/fuzz/optimize_runs/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "optimize_runs"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+afl = "*"
+arbitrary = { version = "1", features = ["derive"] }
+lsm-tree = { path = "../.." }

--- a/fuzz/optimize_runs/src/main.rs
+++ b/fuzz/optimize_runs/src/main.rs
@@ -92,7 +92,10 @@ fn run_operations(operations: impl IntoIterator<Item = Operation>) {
 fn main() {
     fuzz!(|data: &[u8]| {
         let mut unstructured = Unstructured::new(data);
-        let Ok(operations) = Vec::<Operation>::arbitrary(&mut unstructured) else {
+        let Ok(operations) = unstructured.arbitrary_iter::<Operation>() else {
+            return;
+        };
+        let Ok(operations) = operations.take(256).collect::<arbitrary::Result<Vec<_>>>() else {
             return;
         };
 

--- a/fuzz/optimize_runs/src/main.rs
+++ b/fuzz/optimize_runs/src/main.rs
@@ -1,0 +1,145 @@
+#[macro_use]
+extern crate afl;
+
+use arbitrary::{Arbitrary, Unstructured};
+use lsm_tree::{KeyRange, fuzzing::optimize_runs};
+use std::collections::BTreeMap;
+
+#[derive(Arbitrary, Debug)]
+enum Operation {
+    Insert { key: u8, seqno: u64 },
+    Flush,
+}
+
+type Table = BTreeMap<u8, u64>;
+type Runs = Vec<Vec<(usize, KeyRange)>>;
+
+fn verify(runs: &Runs, tables: &[Table], expected: &BTreeMap<u8, u64>) {
+    let mut table_ids = runs
+        .iter()
+        .flat_map(|run| run.iter().map(|(id, _)| *id))
+        .collect::<Vec<_>>();
+    table_ids.sort_unstable();
+    assert_eq!(table_ids, (0..tables.len()).collect::<Vec<_>>());
+
+    for run in runs {
+        for (index, (_, range)) in run.iter().enumerate() {
+            for (_, other) in run.iter().skip(index + 1) {
+                assert!(
+                    !range.overlaps_with_key_range(other),
+                    "optimized run contains overlapping tables: {run:?}"
+                );
+            }
+        }
+    }
+
+    for (&key, &expected_seqno) in expected {
+        let actual = runs.iter().find_map(|run| {
+            run.iter()
+                .find(|(_, range)| range.contains_key(&[key]))
+                .and_then(|(id, _)| tables[*id].get(&key).copied())
+        });
+
+        assert_eq!(
+            actual,
+            Some(expected_seqno),
+            "wrong visible version for key {key}: runs={runs:?}"
+        );
+    }
+}
+
+fn flush(
+    buffer: &mut BTreeMap<u8, u64>,
+    runs: &mut Runs,
+    tables: &mut Vec<Table>,
+    expected: &BTreeMap<u8, u64>,
+) {
+    if !buffer.is_empty() {
+        let min = *buffer.first_key_value().expect("buffer is not empty").0;
+        let max = *buffer.last_key_value().expect("buffer is not empty").0;
+        let id = tables.len();
+
+        tables.push(std::mem::take(buffer));
+        runs.insert(
+            0,
+            vec![(id, KeyRange::new((vec![min].into(), vec![max].into())))],
+        );
+        *runs = optimize_runs(std::mem::take(runs));
+    }
+
+    verify(runs, tables, expected);
+}
+
+fn run_operations(operations: impl IntoIterator<Item = Operation>) {
+    let mut buffer = BTreeMap::new();
+    let mut expected = BTreeMap::new();
+    let mut tables = Vec::new();
+    let mut runs = Vec::new();
+
+    for operation in operations.into_iter().take(256) {
+        match operation {
+            Operation::Insert { key, seqno } => {
+                buffer.insert(key, seqno);
+                expected.insert(key, seqno);
+            }
+            Operation::Flush => flush(&mut buffer, &mut runs, &mut tables, &expected),
+        }
+    }
+
+    flush(&mut buffer, &mut runs, &mut tables, &expected);
+}
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let mut unstructured = Unstructured::new(data);
+        let Ok(operations) = Vec::<Operation>::arbitrary(&mut unstructured) else {
+            return;
+        };
+
+        run_operations(operations);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transitive_overlap_keeps_the_newest_value_visible() {
+        // Oldest [a, c], middle [a, z], newest [m, p]. The newest table is disjoint from the
+        // oldest but overlaps the middle, so moving it behind the middle would expose seqno 1.
+        run_operations([
+            Operation::Insert {
+                key: b'a',
+                seqno: 0,
+            },
+            Operation::Insert {
+                key: b'c',
+                seqno: 0,
+            },
+            Operation::Flush,
+            Operation::Insert {
+                key: b'a',
+                seqno: 1,
+            },
+            Operation::Insert {
+                key: b'm',
+                seqno: 1,
+            },
+            Operation::Insert {
+                key: b'z',
+                seqno: 1,
+            },
+            Operation::Flush,
+            Operation::Insert {
+                key: b'm',
+                seqno: 2,
+            },
+            Operation::Insert {
+                key: b'p',
+                seqno: 2,
+            },
+            Operation::Flush,
+        ]);
+    }
+}

--- a/fuzz/optimize_runs/src/main.rs
+++ b/fuzz/optimize_runs/src/main.rs
@@ -2,7 +2,7 @@
 extern crate afl;
 
 use arbitrary::{Arbitrary, Unstructured};
-use lsm_tree::{KeyRange, fuzzing::optimize_runs};
+use lsm_tree::{KeyRange, Ranged, Run, optimize_runs as optimize};
 use std::collections::BTreeMap;
 
 #[derive(Arbitrary, Debug)]
@@ -13,6 +13,40 @@ enum Operation {
 
 type Table = BTreeMap<u8, u64>;
 type Runs = Vec<Vec<(usize, KeyRange)>>;
+
+#[derive(Clone)]
+struct FuzzTable {
+    id: usize,
+    key_range: KeyRange,
+}
+
+impl Ranged for FuzzTable {
+    fn key_range(&self) -> &KeyRange {
+        &self.key_range
+    }
+}
+
+fn optimize_runs(runs: Runs) -> Runs {
+    let runs = runs
+        .into_iter()
+        .filter_map(|run| {
+            Run::new(
+                run.into_iter()
+                    .map(|(id, key_range)| FuzzTable { id, key_range })
+                    .collect(),
+            )
+        })
+        .collect();
+
+    optimize(runs)
+        .into_iter()
+        .map(|run| {
+            run.iter()
+                .map(|table| (table.id, table.key_range.clone()))
+                .collect()
+        })
+        .collect()
+}
 
 fn verify(runs: &Runs, tables: &[Table], expected: &BTreeMap<u8, u64>) {
     let mut table_ids = runs
@@ -106,6 +140,26 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn range(min: u8, max: u8) -> KeyRange {
+        KeyRange::new((vec![min].into(), vec![max].into()))
+    }
+
+    #[test]
+    fn optimizer_adapter_preserves_transitive_run_order() {
+        let optimized = optimize_runs(vec![
+            vec![],
+            vec![(2, range(b'm', b'p'))],
+            vec![(1, range(b'a', b'z'))],
+            vec![(0, range(b'a', b'c'))],
+        ]);
+
+        let ids = optimized
+            .iter()
+            .map(|run| run.iter().map(|(id, _)| *id).collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![vec![2], vec![1], vec![0]]);
+    }
 
     #[test]
     fn transitive_overlap_keeps_the_newest_value_visible() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ mod version;
 mod vlog;
 
 #[doc(hidden)]
-pub use version::fuzzing;
+pub use version::{optimize_runs, run::Ranged, Run};
 
 /// User defined key (byte array)
 pub type UserKey = Slice;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@ mod value_type;
 mod version;
 mod vlog;
 
+#[doc(hidden)]
+pub use version::fuzzing;
+
 /// User defined key (byte array)
 pub type UserKey = Slice;
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -9,74 +9,9 @@ pub mod recovery;
 pub mod run;
 mod super_version;
 
-#[doc(hidden)]
-pub mod fuzzing {
-    use super::{optimize::optimize_runs as optimize, run::Ranged, Run};
-    use crate::KeyRange;
-
-    #[derive(Clone)]
-    struct FuzzTable {
-        id: usize,
-        key_range: KeyRange,
-    }
-
-    impl Ranged for FuzzTable {
-        fn key_range(&self) -> &KeyRange {
-            &self.key_range
-        }
-    }
-
-    /// Runs the production optimizer over fuzz-table IDs and their key ranges.
-    #[must_use]
-    pub fn optimize_runs(runs: Vec<Vec<(usize, KeyRange)>>) -> Vec<Vec<(usize, KeyRange)>> {
-        let runs = runs
-            .into_iter()
-            .filter_map(|run| {
-                Run::new(
-                    run.into_iter()
-                        .map(|(id, key_range)| FuzzTable { id, key_range })
-                        .collect(),
-                )
-            })
-            .collect();
-
-        optimize(runs)
-            .into_iter()
-            .map(|run| {
-                run.iter()
-                    .map(|table| (table.id, table.key_range.clone()))
-                    .collect()
-            })
-            .collect()
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        fn range(min: u8, max: u8) -> KeyRange {
-            KeyRange::new((vec![min].into(), vec![max].into()))
-        }
-
-        #[test]
-        fn optimizer_adapter_preserves_transitive_run_order() {
-            let optimized = optimize_runs(vec![
-                vec![],
-                vec![(2, range(b'm', b'p'))],
-                vec![(1, range(b'a', b'z'))],
-                vec![(0, range(b'a', b'c'))],
-            ]);
-
-            let ids = optimized
-                .iter()
-                .map(|run| run.iter().map(|(id, _)| *id).collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-            assert_eq!(ids, vec![vec![2], vec![1], vec![0]]);
-        }
-    }
-}
-
 pub use blob_file_list::BlobFileList;
+#[doc(hidden)]
+pub use optimize::optimize_runs;
 pub use persist::persist_version;
 pub use run::Run;
 pub use super_version::{SuperVersion, SuperVersions};
@@ -91,7 +26,6 @@ use crate::{
     vlog::{BlobFile, BlobFileId},
     HashSet, KeyRange, Table, TableId,
 };
-use optimize::optimize_runs;
 use run::Ranged;
 use std::{ops::Deref, sync::Arc};
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -9,6 +9,48 @@ pub mod recovery;
 pub mod run;
 mod super_version;
 
+#[doc(hidden)]
+pub mod fuzzing {
+    use super::{optimize::optimize_runs as optimize, run::Ranged, Run};
+    use crate::KeyRange;
+
+    #[derive(Clone)]
+    struct FuzzTable {
+        id: usize,
+        key_range: KeyRange,
+    }
+
+    impl Ranged for FuzzTable {
+        fn key_range(&self) -> &KeyRange {
+            &self.key_range
+        }
+    }
+
+    /// Runs the production optimizer over fuzz-table IDs and their key ranges.
+    #[must_use]
+    pub fn optimize_runs(runs: Vec<Vec<(usize, KeyRange)>>) -> Vec<Vec<(usize, KeyRange)>> {
+        let runs = runs
+            .into_iter()
+            .filter_map(|run| {
+                Run::new(
+                    run.into_iter()
+                        .map(|(id, key_range)| FuzzTable { id, key_range })
+                        .collect(),
+                )
+            })
+            .collect();
+
+        optimize(runs)
+            .into_iter()
+            .map(|run| {
+                run.iter()
+                    .map(|table| (table.id, table.key_range.clone()))
+                    .collect()
+            })
+            .collect()
+    }
+}
+
 pub use blob_file_list::BlobFileList;
 pub use persist::persist_version;
 pub use run::Run;

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -49,6 +49,31 @@ pub mod fuzzing {
             })
             .collect()
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn range(min: u8, max: u8) -> KeyRange {
+            KeyRange::new((vec![min].into(), vec![max].into()))
+        }
+
+        #[test]
+        fn optimizer_adapter_preserves_transitive_run_order() {
+            let optimized = optimize_runs(vec![
+                vec![],
+                vec![(2, range(b'm', b'p'))],
+                vec![(1, range(b'a', b'z'))],
+                vec![(0, range(b'a', b'c'))],
+            ]);
+
+            let ids = optimized
+                .iter()
+                .map(|run| run.iter().map(|(id, _)| *id).collect::<Vec<_>>())
+                .collect::<Vec<_>>();
+            assert_eq!(ids, vec![vec![2], vec![1], vec![0]]);
+        }
+    }
 }
 
 pub use blob_file_list::BlobFileList;

--- a/src/version/optimize.rs
+++ b/src/version/optimize.rs
@@ -5,6 +5,8 @@
 use super::run::Ranged;
 use crate::version::Run;
 
+#[doc(hidden)]
+#[must_use]
 pub fn optimize_runs<T: Clone + Ranged>(runs: Vec<Run<T>>) -> Vec<Run<T>> {
     if runs.len() <= 1 {
         runs

--- a/src/version/run.rs
+++ b/src/version/run.rs
@@ -5,6 +5,7 @@
 use crate::KeyRange;
 use std::ops::{Bound, RangeBounds};
 
+#[doc(hidden)]
 pub trait Ranged {
     fn key_range(&self) -> &KeyRange;
 }
@@ -50,6 +51,7 @@ impl<T: Ranged> std::ops::Deref for Indexed<T> {
 
 /// A disjoint run of tables
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[doc(hidden)]
 pub struct Run<T: Ranged>(Vec<T>);
 
 impl<T: Ranged> std::ops::Deref for Run<T> {
@@ -60,6 +62,11 @@ impl<T: Ranged> std::ops::Deref for Run<T> {
     }
 }
 
+#[allow(
+    clippy::missing_panics_doc,
+    clippy::must_use_candidate,
+    reason = "Run is only publicly exported as a hidden fuzzing implementation detail"
+)]
 impl<T: Ranged> Run<T> {
     pub fn new(items: Vec<T>) -> Option<Self> {
         if items.is_empty() {


### PR DESCRIPTION
Fixes #318

## Summary

- add an AFL target that models inserts and flushes with in-memory faux tables
- compare optimized point visibility with a `BTreeMap` last-write model after every flush
- assert table preservation and per-run range disjointness
- expose a narrow, doc-hidden adapter around the production optimizer
- include a deterministic transitive-overlap regression seed

## Validation

- `cargo test --manifest-path fuzz/optimize_runs/Cargo.toml`
- `cargo afl build --manifest-path fuzz/optimize_runs/Cargo.toml`
- 10-second AFL smoke run: 0 crashes, 0 timeouts
- `cargo test --all-features`
- `cargo test --doc --features lz4`
- `cargo clippy`
- `cargo clippy --manifest-path fuzz/optimize_runs/Cargo.toml --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path fuzz/optimize_runs/Cargo.toml -- --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Added automated fuzz testing for data-run optimization, including inserts, flushes, overlapping ranges, ordering, table coverage, and value visibility.
  * Added regression coverage for complex transitive overlaps and newest-value selection.

* **Reliability**
  * Expanded validation of run coverage, ordering, overlap handling, and visible values.

* **Chores**
  * Added supporting infrastructure for storage reliability and optimization testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->